### PR TITLE
feat(codex): standardized trace metadata [LSEN-308]

### DIFF
--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.6",
+  "version": "0.0.4",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -3,6 +3,8 @@ import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
 import { Worker } from "node:worker_threads";
 import * as os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 //#region \0rolldown/runtime.js
 var __create = Object.create;
 var __defProp = Object.defineProperty;
@@ -11696,7 +11698,7 @@ function parseJson(value) {
 		return;
 	}
 }
-const stripUndefined = (value) => {
+const stripUndefined$1 = (value) => {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 };
 async function readConfigFile(file) {
@@ -11712,7 +11714,7 @@ function getVar(suffix, env) {
 }
 const readConfigEnv = (env) => {
 	const enabled = parseBoolean(env.TRACE_TO_LANGSMITH);
-	return stripUndefined(PartialConfigSchema.parse({
+	return stripUndefined$1(PartialConfigSchema.parse({
 		enabled,
 		api_key: getVar("API_KEY", env),
 		api_url: getVar("ENDPOINT", env),
@@ -11758,6 +11760,111 @@ async function markTurnUploaded(rolloutFile, turnId) {
 	} catch (error) {
 		return false;
 	}
+}
+//#endregion
+//#region src/metadata.ts
+const execFileAsync = promisify(execFile);
+const LS_AGENT_KIND = "coding_agent";
+const LS_INTEGRATION = "openai-codex";
+const LS_AGENT_RUNTIME = "Codex";
+const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+const LS_INTEGRATION_VERSION = "0.0.3";
+function stripUndefined(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
+}
+function parseRepository(url) {
+	const normalized = url?.trim();
+	if (!normalized) return {};
+	let host;
+	let pathname;
+	const scp = /^[^/@]+@([^:/]+):(.+)$/.exec(normalized);
+	if (scp) {
+		host = scp[1];
+		pathname = scp[2];
+	} else try {
+		const parsed = new URL(normalized);
+		host = parsed.hostname;
+		pathname = parsed.pathname;
+	} catch {
+		return { repository_url: normalized };
+	}
+	const provider = (() => {
+		const h = (host ?? "").toLowerCase();
+		if (h.includes("github")) return "github";
+		if (h.includes("gitlab")) return "gitlab";
+		if (h.includes("bitbucket")) return "bitbucket";
+		return h || "other";
+	})();
+	const name = (pathname ?? "").replace(/^\/+/, "").replace(/\.git$/, "").split("/").filter(Boolean).pop() || void 0;
+	return {
+		repository_url: normalized.replace(/\.git$/, ""),
+		repository_provider: provider,
+		repository_name: name
+	};
+}
+async function runGit(cwd, args) {
+	try {
+		const { stdout } = await execFileAsync("git", args, {
+			cwd,
+			timeout: 2e3
+		});
+		const out = stdout.trim();
+		return out.length > 0 ? out : void 0;
+	} catch {
+		return;
+	}
+}
+const gitInfoCache = /* @__PURE__ */ new Map();
+async function resolveGitInfo(cwd, sessionGit) {
+	if (sessionGit != null && (sessionGit.repository_url != null || sessionGit.commit_hash != null || sessionGit.branch != null)) return sessionGit;
+	if (!cwd) return void 0;
+	let pending = gitInfoCache.get(cwd);
+	if (pending == null) {
+		pending = (async () => {
+			const [repository_url, branch, commit_hash] = await Promise.all([
+				runGit(cwd, [
+					"remote",
+					"get-url",
+					"origin"
+				]),
+				runGit(cwd, [
+					"rev-parse",
+					"--abbrev-ref",
+					"HEAD"
+				]),
+				runGit(cwd, ["rev-parse", "HEAD"])
+			]);
+			if (repository_url == null && branch == null && commit_hash == null) return;
+			return {
+				repository_url,
+				branch,
+				commit_hash
+			};
+		})();
+		gitInfoCache.set(cwd, pending);
+	}
+	return pending;
+}
+function codingAgentMetadata(ctx) {
+	const repo = parseRepository(ctx.git?.repository_url);
+	return stripUndefined({
+		ls_agent_kind: LS_AGENT_KIND,
+		ls_integration: LS_INTEGRATION,
+		ls_agent_runtime: LS_AGENT_RUNTIME,
+		thread_id: ctx.threadId,
+		ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+		ls_integration_version: LS_INTEGRATION_VERSION,
+		ls_agent_runtime_version: ctx.cliVersion,
+		turn_id: ctx.turnId,
+		turn_number: ctx.turnNumber,
+		repository_url: repo.repository_url,
+		repository_provider: repo.repository_provider,
+		repository_name: repo.repository_name,
+		git_branch: ctx.git?.branch,
+		git_commit_sha: ctx.git?.commit_hash,
+		cwd: ctx.cwd,
+		sandbox_type: ctx.sandboxType
+	});
 }
 //#endregion
 //#region src/utils/isPrimitive.ts
@@ -11977,6 +12084,11 @@ function convertToStandardMessages(messages) {
 		};
 	});
 }
+const CHILD_SCOPE_RESET = {
+	approval_policy: void 0,
+	ls_subagent_id: void 0,
+	ls_subagent_type: void 0
+};
 function getUsageMetadata(counts) {
 	if (counts == null || Object.values(counts ?? {}).every((value) => value == null)) return;
 	return {
@@ -12016,6 +12128,32 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		now: Date.now(),
 		startTime: parentStartTime
 	};
+	const cwd = (typeof task.context?.cwd === "string" ? task.context.cwd : void 0) ?? sessionMeta?.cwd;
+	const sandboxType = (() => {
+		const policy = task.context?.sandbox_policy;
+		if (typeof policy === "string") return policy;
+		if (policy != null && typeof policy === "object") {
+			const type = policy.type;
+			if (typeof type === "string") return type;
+		}
+	})();
+	const approvalPolicy = (() => {
+		const policy = task.context?.approval_policy;
+		if (typeof policy === "string") return policy;
+		if (policy != null) return JSON.stringify(policy);
+	})();
+	const git = await resolveGitInfo(cwd, sessionMeta?.git);
+	const conversationThreadId = options?.threadId ?? sessionMeta?.session_id;
+	const base = codingAgentMetadata({
+		threadId: conversationThreadId,
+		turnId: task.turnId?.id,
+		turnNumber: task.turnNumber,
+		cliVersion: sessionMeta?.cli_version,
+		cwd,
+		git,
+		sandboxType
+	});
+	const isSubagent = sessionMeta?.is_subagent === true;
 	const parentConfig = {
 		name: "openai.codex",
 		client: options?.client,
@@ -12029,11 +12167,12 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		extra: { metadata: {
 			...options?.metadata,
 			...task.context,
+			...base,
+			approval_policy: isSubagent ? void 0 : approvalPolicy,
+			ls_subagent_id: isSubagent ? sessionMeta?.session_id : void 0,
+			ls_subagent_type: isSubagent ? sessionMeta?.agent_role ?? sessionMeta?.agent_nickname : void 0,
 			codex_cli_version: sessionMeta?.cli_version,
-			turn_id: task.turnId?.id,
-			thread_id: sessionMeta?.session_id,
-			ls_integration: "openai-codex",
-			ls_agent_type: "root",
+			ls_agent_type: isSubagent ? "subagent" : "root",
 			ls_message_format: "anthropic",
 			usage_metadata: getUsageMetadata(task.tokenCount?.total_token_usage)
 		} }
@@ -12076,6 +12215,8 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			outputs: { messages: aiMessage.map((i) => i.message) },
 			extra: { metadata: {
 				...options?.metadata,
+				...base,
+				...CHILD_SCOPE_RESET,
 				ls_model_type: "chat",
 				ls_provider: sessionMeta?.model_provider,
 				ls_model_name: task.context?.model,
@@ -12096,8 +12237,10 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			};
 			const min = Math.min(toolMessage.timestamp.start, ...toolCall.timings);
 			const max = Math.max(toolMessage.timestamp.end, ...toolCall.timings);
+			const nativeToolName = typeof msgToolCall.name === "string" ? msgToolCall.name : void 0;
+			const runName = nativeToolName ?? "openai.codex.tool";
 			const toolRun = parent.createChild({
-				name: msgToolCall.name ?? "openai.codex.tool",
+				name: runName,
 				run_type: "tool",
 				start_time: min,
 				end_time: max,
@@ -12109,11 +12252,14 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 				error: toolCall.error,
 				extra: { metadata: {
 					...options?.metadata,
+					...base,
+					...CHILD_SCOPE_RESET,
 					ls_model_type: "chat",
 					ls_provider: sessionMeta?.model_provider,
 					ls_model_name: task.context?.model,
 					ls_invocation_params: task.context,
-					usage_metadata: getUsageMetadata(toolMessage.tokenCount)
+					usage_metadata: getUsageMetadata(toolMessage.tokenCount),
+					...nativeToolName != null && runName !== nativeToolName ? { ls_tool_name: nativeToolName } : {}
 				} }
 			});
 			PROMISE_QUEUE.push(toolRun.postRun());
@@ -12129,6 +12275,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			}, {
 				...options,
 				parentRunTree: parent,
+				threadId: conversationThreadId,
 				debugNow
 			});
 		}
@@ -12140,6 +12287,7 @@ async function convertToRunTree(input, options) {
 	function createTask() {
 		return {
 			turnId: void 0,
+			turnNumber: void 0,
 			messages: [],
 			userMessageIndex: void 0,
 			context: void 0,
@@ -12147,15 +12295,25 @@ async function convertToRunTree(input, options) {
 			toolCalls: {}
 		};
 	}
+	let turnNumber = 0;
 	const uploadedTurnIds = await loadUploadedTurnIds(input.transcript_path);
 	const events = await loadSession(input.transcript_path);
 	for (const [index, { type, payload, timestamp }, arr] of enumerate(events)) {
-		if (type === "session_meta") sessionMeta = {
-			session_id: payload.id,
-			model_provider: payload.model_provider ?? void 0,
-			base_instructions: payload.base_instructions?.text,
-			cli_version: payload.cli_version
-		};
+		if (type === "session_meta") {
+			const source = payload.source;
+			const threadSpawn = source != null && typeof source === "object" && "subagent" in source ? source.subagent?.thread_spawn : void 0;
+			sessionMeta = {
+				session_id: payload.id,
+				model_provider: payload.model_provider ?? void 0,
+				base_instructions: payload.base_instructions?.text,
+				cli_version: payload.cli_version,
+				cwd: payload.cwd,
+				git: payload.git,
+				is_subagent: threadSpawn != null,
+				agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? void 0,
+				agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? void 0
+			};
+		}
 		if (type === "response_item") {
 			task ??= createTask();
 			const message = {
@@ -12175,10 +12333,12 @@ async function convertToRunTree(input, options) {
 			const eventTime = Date.parse(timestamp);
 			if (payload.type === "task_started") {
 				task = createTask();
+				turnNumber += 1;
 				task.turnId = {
 					id: payload.turn_id,
 					timestamp: eventTime
 				};
+				task.turnNumber = turnNumber;
 			}
 			if (typeof payload.call_id === "string") {
 				task ??= createTask();
@@ -12224,6 +12384,14 @@ async function convertToRunTree(input, options) {
 			if (payload.type === "task_complete" || payload.type === "turn_aborted" || task != null && index === arr.length - 1 && input.turn_id != null) {
 				task ??= createTask();
 				const completedTurnId = task.turnId?.id ?? input.turn_id ?? void 0;
+				if (task.turnId == null && completedTurnId != null) task.turnId = {
+					id: completedTurnId,
+					timestamp: eventTime
+				};
+				if (task.turnNumber == null) {
+					turnNumber += 1;
+					task.turnNumber = turnNumber;
+				}
 				if (completedTurnId == null || !uploadedTurnIds.has(completedTurnId)) {
 					await postTurn(task, sessionMeta, {
 						rolloutFile: input.transcript_path,

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -11768,7 +11768,7 @@ const LS_AGENT_KIND = "coding_agent";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.5";
+const LS_INTEGRATION_VERSION = "0.0.6";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -11768,7 +11768,7 @@ const LS_AGENT_KIND = "coding_agent";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.6";
+const LS_INTEGRATION_VERSION = "0.0.4";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -12224,8 +12224,8 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		const inputMessages = fullMessages.slice(0, output.start);
 		const aiMessage = fullMessages.slice(output.start, output.start + 1);
 		const toolMessages = fullMessages.slice(output.start + 1, output.start + output.length);
-		const outputStartTime = aiMessage.at(0)?.timestamp.start ?? parentStartTime;
-		const outputEndTime = aiMessage.at(-1)?.timestamp.end ?? outputStartTime;
+		const outputStartTime = inputMessages.at(-1)?.timestamp.end ?? aiMessage.at(0)?.timestamp.start ?? parentStartTime;
+		const outputEndTime = Math.max(aiMessage.at(-1)?.timestamp.end ?? outputStartTime, outputStartTime);
 		const tokenCounts = findLast(aiMessage, (i) => i.tokenCount != null)?.tokenCount;
 		const subagentThreads = findLast(aiMessage, (i) => i.subagentThreads.length > 0)?.subagentThreads;
 		const llmChild = parent.createChild({
@@ -12257,7 +12257,8 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 				timings: [],
 				outputs: {}
 			};
-			const min = Math.min(toolMessage.timestamp.start, ...toolCall.timings);
+			const callTime = aiMessage.at(0)?.timestamp.start;
+			const min = Math.min(toolMessage.timestamp.start, ...callTime != null ? [callTime] : [], ...toolCall.timings);
 			const max = Math.max(toolMessage.timestamp.end, ...toolCall.timings);
 			const nativeToolName = typeof msgToolCall.name === "string" ? msgToolCall.name : void 0;
 			const runName = nativeToolName ?? "openai.codex.tool";

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -11795,7 +11795,7 @@ function parseRepository(url) {
 		if (h.includes("bitbucket")) return "bitbucket";
 		return h || "other";
 	})();
-	const name = (pathname ?? "").replace(/^\/+/, "").replace(/\.git$/, "").split("/").filter(Boolean).pop() || void 0;
+	const name = (pathname ?? "").replace(/^\/+/, "").replace(/\.git$/, "").split("/").filter(Boolean).slice(-2).join("/") || void 0;
 	return {
 		repository_url: normalized.replace(/\.git$/, ""),
 		repository_provider: provider,

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -12143,9 +12143,9 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		if (policy != null) return JSON.stringify(policy);
 	})();
 	const git = await resolveGitInfo(cwd, sessionMeta?.git);
-	const conversationThreadId = options?.threadId ?? sessionMeta?.session_id;
+	const isSubagent = sessionMeta?.is_subagent === true;
 	const base = codingAgentMetadata({
-		threadId: conversationThreadId,
+		threadId: (isSubagent ? sessionMeta?.parent_thread_id : void 0) ?? sessionMeta?.session_id,
 		turnId: task.turnId?.id,
 		turnNumber: task.turnNumber,
 		cliVersion: sessionMeta?.cli_version,
@@ -12153,7 +12153,6 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		git,
 		sandboxType
 	});
-	const isSubagent = sessionMeta?.is_subagent === true;
 	const parentConfig = {
 		name: "openai.codex",
 		client: options?.client,
@@ -12275,7 +12274,6 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			}, {
 				...options,
 				parentRunTree: parent,
-				threadId: conversationThreadId,
 				debugNow
 			});
 		}
@@ -12310,6 +12308,7 @@ async function convertToRunTree(input, options) {
 				cwd: payload.cwd,
 				git: payload.git,
 				is_subagent: threadSpawn != null,
+				parent_thread_id: threadSpawn?.parent_thread_id ?? void 0,
 				agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? void 0,
 				agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? void 0
 			};

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -11768,7 +11768,7 @@ const LS_AGENT_KIND = "coding_agent";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.3";
+const LS_INTEGRATION_VERSION = "0.0.5";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }
@@ -11885,9 +11885,32 @@ function* enumerate(arr) {
 async function loadSession(name) {
 	return (await nodeFsPromises.readFile(name, "utf-8")).split("\n").filter(Boolean).map((line) => JSON.parse(line));
 }
-async function findRolloutFileByThreadId(parentFileName, threadId) {
+function extractSpawnedAgentId(output) {
+	let obj = output;
+	if (typeof output === "string") try {
+		obj = JSON.parse(output);
+	} catch {
+		return;
+	}
+	if (obj != null && typeof obj === "object") {
+		const id = obj.agent_id;
+		if (typeof id === "string") return id;
+	}
+}
+function resolveSessionsRoot(parentFileName, sessionsRoot) {
+	if (sessionsRoot) return sessionsRoot;
+	let dir = nodePath.dirname(nodePath.resolve(parentFileName));
+	while (true) {
+		if (nodePath.basename(dir) === "sessions") return dir;
+		const up = nodePath.dirname(dir);
+		if (up === dir) break;
+		dir = up;
+	}
+	return nodePath.join(os.homedir(), ".codex", "sessions");
+}
+async function findRolloutFileByThreadId(parentFileName, threadId, sessionsRoot) {
 	const suffix = `-${threadId}.jsonl`;
-	const root = nodePath.resolve(nodePath.dirname(parentFileName), "../../..");
+	const root = resolveSessionsRoot(parentFileName, sessionsRoot);
 	async function walk(dir) {
 		let entries;
 		try {
@@ -12264,7 +12287,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			PROMISE_QUEUE.push(toolRun.postRun());
 		}
 		for (const subagentThread of subagentThreads ?? []) {
-			const subagentFile = await findRolloutFileByThreadId(rolloutFile, subagentThread);
+			const subagentFile = await findRolloutFileByThreadId(rolloutFile, subagentThread, options?.sessionsRoot);
 			if (subagentFile == null) continue;
 			await convertToRunTree({
 				transcript_path: subagentFile,
@@ -12294,6 +12317,7 @@ async function convertToRunTree(input, options) {
 		};
 	}
 	let turnNumber = 0;
+	const spawnAgentMessages = /* @__PURE__ */ new Map();
 	const uploadedTurnIds = await loadUploadedTurnIds(input.transcript_path);
 	const events = await loadSession(input.transcript_path);
 	for (const [index, { type, payload, timestamp }, arr] of enumerate(events)) {
@@ -12322,6 +12346,11 @@ async function convertToRunTree(input, options) {
 				subagentThreads: []
 			};
 			task.messages.push(message);
+			if (payload.type === "function_call" && payload.name === "spawn_agent") spawnAgentMessages.set(payload.call_id, message);
+			else if (payload.type === "function_call_output" && spawnAgentMessages.has(payload.call_id)) {
+				const childId = extractSpawnedAgentId(payload.output);
+				if (childId != null) spawnAgentMessages.get(payload.call_id)?.subagentThreads.push(childId);
+			}
 			if (task.context != null && task.userMessageIndex == null && payload.type === "message" && payload.role === "user") task.userMessageIndex = task.messages.length - 1;
 		}
 		if (type === "turn_context") {

--- a/plugins/tracing/src/metadata.ts
+++ b/plugins/tracing/src/metadata.ts
@@ -1,0 +1,175 @@
+// Shared coding-agent-v1 trace-metadata contract for the Codex plugin.
+// Spec: Coding-Agent Trace Metadata Standard (coding-agent-v1) / LSEN-277.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { GitInfo } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+// Frozen literals for the Codex integration (see validator.json).
+export const LS_AGENT_KIND = "coding_agent";
+export const LS_INTEGRATION = "openai-codex";
+export const LS_AGENT_RUNTIME = "Codex";
+export const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+
+// Plugin version, injected at build time via bundler `define`.
+// `typeof` guards the case where the define was not applied.
+declare const __LS_INTEGRATION_VERSION__: string;
+export const LS_INTEGRATION_VERSION: string | undefined =
+  typeof __LS_INTEGRATION_VERSION__ === "string" && __LS_INTEGRATION_VERSION__.length > 0
+    ? __LS_INTEGRATION_VERSION__
+    : undefined;
+
+function stripUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}
+
+// Derive repository_provider/repository_name from an https or scp git remote URL.
+export function parseRepository(url: string | undefined): {
+  repository_url?: string;
+  repository_provider?: string;
+  repository_name?: string;
+} {
+  const normalized = url?.trim();
+  if (!normalized) return {};
+
+  let host: string | undefined;
+  let pathname: string | undefined;
+
+  // scp-like syntax: git@github.com:org/repo.git
+  const scp = /^[^/@]+@([^:/]+):(.+)$/.exec(normalized);
+  if (scp) {
+    host = scp[1];
+    pathname = scp[2];
+  } else {
+    try {
+      const parsed = new URL(normalized);
+      host = parsed.hostname;
+      pathname = parsed.pathname;
+    } catch {
+      // Unparseable remote — still surface the raw URL.
+      return { repository_url: normalized };
+    }
+  }
+
+  const provider = (() => {
+    const h = (host ?? "").toLowerCase();
+    if (h.includes("github")) return "github";
+    if (h.includes("gitlab")) return "gitlab";
+    if (h.includes("bitbucket")) return "bitbucket";
+    return h || "other";
+  })();
+
+  const name =
+    (pathname ?? "")
+      .replace(/^\/+/, "")
+      .replace(/\.git$/, "")
+      .split("/")
+      .filter(Boolean)
+      .pop() || undefined;
+
+  return {
+    repository_url: normalized.replace(/\.git$/, ""),
+    repository_provider: provider,
+    repository_name: name,
+  };
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", args, { cwd, timeout: 2000 });
+    const out = stdout.trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Cache per cwd so we probe `git` at most once per workspace.
+const gitInfoCache = new Map<string, Promise<GitInfo | undefined>>();
+
+// Prefer the rollout's own session_meta.git; otherwise fall back to the git CLI.
+export async function resolveGitInfo(
+  cwd: string | undefined,
+  sessionGit: GitInfo | undefined,
+): Promise<GitInfo | undefined> {
+  if (
+    sessionGit != null &&
+    (sessionGit.repository_url != null ||
+      sessionGit.commit_hash != null ||
+      sessionGit.branch != null)
+  ) {
+    return sessionGit;
+  }
+
+  if (!cwd) return undefined;
+
+  let pending = gitInfoCache.get(cwd);
+  if (pending == null) {
+    pending = (async () => {
+      const [repository_url, branch, commit_hash] = await Promise.all([
+        runGit(cwd, ["remote", "get-url", "origin"]),
+        runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]),
+        runGit(cwd, ["rev-parse", "HEAD"]),
+      ]);
+      if (repository_url == null && branch == null && commit_hash == null) {
+        return undefined;
+      }
+      return { repository_url, branch, commit_hash };
+    })();
+    gitInfoCache.set(cwd, pending);
+  }
+  return pending;
+}
+
+export interface CodingAgentContext {
+  /** Stable conversation/thread id used to group turns (Codex `thread_id`/session id). */
+  threadId?: string;
+  /** Stable per-turn id (Codex `turn_id`). */
+  turnId?: string;
+  /** 1-based native turn index within the thread. */
+  turnNumber?: number;
+  /** Codex CLI runtime version. */
+  cliVersion?: string;
+  /** Working directory for the turn. */
+  cwd?: string;
+  /** Resolved git info for the workspace. */
+  git?: GitInfo;
+  /** Sandbox / runtime isolation provider. */
+  sandboxType?: string;
+}
+
+// Base contract merged onto every run; run-type-scoped keys are added at call
+// sites. Unknown values are omitted.
+export function codingAgentMetadata(ctx: CodingAgentContext): Record<string, unknown> {
+  const repo = parseRepository(ctx.git?.repository_url);
+
+  return stripUndefined({
+    // Identity & grouping — required on every run.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    thread_id: ctx.threadId,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+
+    // Versions & turn.
+    ls_integration_version: LS_INTEGRATION_VERSION,
+    ls_agent_runtime_version: ctx.cliVersion,
+    turn_id: ctx.turnId,
+    turn_number: ctx.turnNumber,
+
+    // Git & workspace.
+    repository_url: repo.repository_url,
+    repository_provider: repo.repository_provider,
+    repository_name: repo.repository_name,
+    git_branch: ctx.git?.branch,
+    git_commit_sha: ctx.git?.commit_hash,
+    cwd: ctx.cwd,
+
+    // Environment.
+    sandbox_type: ctx.sandboxType,
+  });
+}

--- a/plugins/tracing/src/metadata.ts
+++ b/plugins/tracing/src/metadata.ts
@@ -63,13 +63,15 @@ export function parseRepository(url: string | undefined): {
     return h || "other";
   })();
 
+  // Full org/repo slug (e.g. langchain-ai/langsmith-codex-plugins), not bare repo.
   const name =
     (pathname ?? "")
       .replace(/^\/+/, "")
       .replace(/\.git$/, "")
       .split("/")
       .filter(Boolean)
-      .pop() || undefined;
+      .slice(-2)
+      .join("/") || undefined;
 
   return {
     repository_url: normalized.replace(/\.git$/, ""),

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -472,8 +472,13 @@ async function postTurn(
     const aiMessage = fullMessages.slice(output.start, output.start + 1);
     const toolMessages = fullMessages.slice(output.start + 1, output.start + output.length);
 
-    const outputStartTime = aiMessage.at(0)?.timestamp.start ?? parentStartTime;
-    const outputEndTime = aiMessage.at(-1)?.timestamp.end ?? outputStartTime;
+    // Span the LLM from the prior message to its response, not its own instant.
+    const outputStartTime =
+      inputMessages.at(-1)?.timestamp.end ?? aiMessage.at(0)?.timestamp.start ?? parentStartTime;
+    const outputEndTime = Math.max(
+      aiMessage.at(-1)?.timestamp.end ?? outputStartTime,
+      outputStartTime,
+    );
 
     const tokenCounts = findLast(aiMessage, (i) => i.tokenCount != null)?.tokenCount;
 
@@ -524,7 +529,13 @@ async function postTurn(
         outputs: {},
       };
 
-      const min = Math.min(toolMessage.timestamp.start, ...toolCall.timings);
+      // Span the tool from its call to its output (begin/end events if present).
+      const callTime = aiMessage.at(0)?.timestamp.start;
+      const min = Math.min(
+        toolMessage.timestamp.start,
+        ...(callTime != null ? [callTime] : []),
+        ...toolCall.timings,
+      );
       const max = Math.max(toolMessage.timestamp.end, ...toolCall.timings);
 
       const nativeToolName = typeof msgToolCall.name === "string" ? msgToolCall.name : undefined;

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -1,10 +1,11 @@
-import type { LineSchema, ResponseItem } from "./types.js";
+import type { LineSchema, ResponseItem, SubagentSource } from "./types.js";
 import { Client, RunTreeConfig, RunTree } from "langsmith";
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { findLast } from "./utils/findLast.js";
 import { loadUploadedTurnIds, markTurnUploaded } from "./sidecar.js";
+import { codingAgentMetadata, resolveGitInfo } from "./metadata.js";
 import type {
   Session,
   TokenCount,
@@ -244,6 +245,14 @@ function convertToStandardMessages(messages: AggregateMessage<ResponseItem>[]) {
   });
 }
 
+// Null run-type-scoped keys on llm/tool runs to override langsmith's
+// parent->child metadata inheritance (serialization drops undefined).
+const CHILD_SCOPE_RESET = {
+  approval_policy: undefined,
+  ls_subagent_id: undefined,
+  ls_subagent_type: undefined,
+} as const;
+
 function getUsageMetadata(counts: TokenCount | undefined): Record<string, unknown> | undefined {
   if (counts == null || Object.values(counts ?? {}).every((value) => value == null)) {
     return undefined;
@@ -277,6 +286,8 @@ async function postTurn(
       replicas?: RunTreeConfig["replicas"];
 
       parentRunTree?: RunTree;
+      // Root conversation thread_id, propagated to subagent runs for grouping.
+      threadId?: string;
       debugNow?: { now: number; startTime: number };
     };
   },
@@ -322,6 +333,47 @@ async function postTurn(
 
   const debugNow = options?.debugNow ?? { now: Date.now(), startTime: parentStartTime };
 
+  // Codex turn-context carries the workspace + policy details for this turn.
+  const cwd =
+    (typeof task.context?.cwd === "string" ? task.context.cwd : undefined) ?? sessionMeta?.cwd;
+
+  const sandboxType = (() => {
+    const policy = task.context?.sandbox_policy;
+    if (typeof policy === "string") return policy;
+    if (policy != null && typeof policy === "object") {
+      const type = (policy as { type?: unknown }).type;
+      if (typeof type === "string") return type;
+    }
+    return undefined;
+  })();
+
+  const approvalPolicy = (() => {
+    const policy = task.context?.approval_policy;
+    if (typeof policy === "string") return policy;
+    if (policy != null) return JSON.stringify(policy);
+    return undefined;
+  })();
+
+  const git = await resolveGitInfo(cwd, sessionMeta?.git);
+
+  // thread_id groups the whole conversation; subagents inherit the root's.
+  const conversationThreadId = options?.threadId ?? sessionMeta?.session_id;
+
+  // coding-agent-v1 base contract, stamped onto every run below.
+  const base = codingAgentMetadata({
+    threadId: conversationThreadId,
+    turnId: task.turnId?.id,
+    turnNumber: task.turnNumber,
+    cliVersion: sessionMeta?.cli_version,
+    cwd,
+    git,
+    sandboxType,
+  });
+
+  const isSubagent = sessionMeta?.is_subagent === true;
+
+  // Scope-restricted keys: approval_policy on root only, ls_subagent_* on
+  // subagent only. Set undefined elsewhere to override inherited values.
   const parentConfig: RunTreeConfig = {
     name: "openai.codex",
     client: options?.client,
@@ -336,12 +388,18 @@ async function postTurn(
       metadata: {
         ...options?.metadata,
         ...task.context,
-        codex_cli_version: sessionMeta?.cli_version,
-        turn_id: task.turnId?.id,
-        thread_id: sessionMeta?.session_id,
+        ...base,
 
-        ls_integration: "openai-codex",
-        ls_agent_type: "root",
+        approval_policy: isSubagent ? undefined : approvalPolicy,
+        ls_subagent_id: isSubagent ? sessionMeta?.session_id : undefined,
+        ls_subagent_type: isSubagent
+          ? (sessionMeta?.agent_role ?? sessionMeta?.agent_nickname)
+          : undefined,
+
+        // Deprecated compat aliases (>=1 release): codex_cli_version,
+        // ls_agent_type.
+        codex_cli_version: sessionMeta?.cli_version,
+        ls_agent_type: isSubagent ? "subagent" : "root",
         ls_message_format: "anthropic",
 
         usage_metadata: getUsageMetadata(task.tokenCount?.total_token_usage),
@@ -402,6 +460,8 @@ async function postTurn(
       extra: {
         metadata: {
           ...options?.metadata,
+          ...base,
+          ...CHILD_SCOPE_RESET,
           ls_model_type: "chat",
           ls_provider: sessionMeta?.model_provider,
           ls_model_name: task.context?.model,
@@ -435,8 +495,11 @@ async function postTurn(
       const min = Math.min(toolMessage.timestamp.start, ...toolCall.timings);
       const max = Math.max(toolMessage.timestamp.end, ...toolCall.timings);
 
+      const nativeToolName = typeof msgToolCall.name === "string" ? msgToolCall.name : undefined;
+      const runName = nativeToolName ?? "openai.codex.tool";
+
       const toolRun = parent.createChild({
-        name: (msgToolCall.name as string) ?? "openai.codex.tool",
+        name: runName,
         run_type: "tool",
         start_time: min,
         end_time: max,
@@ -446,11 +509,17 @@ async function postTurn(
         extra: {
           metadata: {
             ...options?.metadata,
+            ...base,
+            ...CHILD_SCOPE_RESET,
             ls_model_type: "chat",
             ls_provider: sessionMeta?.model_provider,
             ls_model_name: task.context?.model,
             ls_invocation_params: task.context,
             usage_metadata: getUsageMetadata(toolMessage.tokenCount),
+            // Native tool name, only when it differs from the run name.
+            ...(nativeToolName != null && runName !== nativeToolName
+              ? { ls_tool_name: nativeToolName }
+              : {}),
           },
         },
       });
@@ -475,7 +544,7 @@ async function postTurn(
 
       await convertToRunTree(
         { transcript_path: subagentFile, turn_id: lastTurnId },
-        { ...options, parentRunTree: parent, debugNow },
+        { ...options, parentRunTree: parent, threadId: conversationThreadId, debugNow },
       );
     }
   }
@@ -490,6 +559,8 @@ export async function convertToRunTree(
     replicas?: RunTreeConfig["replicas"];
     projectName?: string;
     sessionsRoot?: string;
+    // Root conversation thread_id, propagated to subagent runs for grouping.
+    threadId?: string;
     debugNow?: { now: number; startTime: number };
   },
 ) {
@@ -499,6 +570,7 @@ export async function convertToRunTree(
   function createTask(): Task {
     return {
       turnId: undefined,
+      turnNumber: undefined,
       messages: [],
       userMessageIndex: undefined,
       context: undefined,
@@ -507,6 +579,9 @@ export async function convertToRunTree(
     };
   }
 
+  // 1-based native turn index within this thread; incremented per task_started.
+  let turnNumber = 0;
+
   // Turns that have already been uploaded in a previous hook invocation for the
   // same rollout file. Used to avoid replaying completed turns when the user
   // resumes or continues a conversation.
@@ -514,11 +589,23 @@ export async function convertToRunTree(
   const events = await loadSession(input.transcript_path);
   for (const [index, { type, payload, timestamp }, arr] of enumerate(events)) {
     if (type === "session_meta") {
+      // Subagent threads carry `source.subagent.thread_spawn`; roots use "cli".
+      const source = payload.source;
+      const threadSpawn =
+        source != null && typeof source === "object" && "subagent" in source
+          ? (source as SubagentSource).subagent?.thread_spawn
+          : undefined;
+
       sessionMeta = {
         session_id: payload.id,
         model_provider: payload.model_provider ?? undefined,
         base_instructions: payload.base_instructions?.text,
         cli_version: payload.cli_version,
+        cwd: payload.cwd,
+        git: payload.git,
+        is_subagent: threadSpawn != null,
+        agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? undefined,
+        agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? undefined,
       };
     }
 
@@ -555,7 +642,9 @@ export async function convertToRunTree(
       if (payload.type === "task_started") {
         // TODO: should we try to flush?
         task = createTask();
+        turnNumber += 1;
         task.turnId = { id: payload.turn_id, timestamp: eventTime };
+        task.turnNumber = turnNumber;
       }
 
       if (typeof payload.call_id === "string") {
@@ -624,6 +713,14 @@ export async function convertToRunTree(
       ) {
         task ??= createTask();
         const completedTurnId = task.turnId?.id ?? input.turn_id ?? undefined;
+        // Ensure a turn marker for turns completed without a task_started.
+        if (task.turnId == null && completedTurnId != null) {
+          task.turnId = { id: completedTurnId, timestamp: eventTime };
+        }
+        if (task.turnNumber == null) {
+          turnNumber += 1;
+          task.turnNumber = turnNumber;
+        }
         if (completedTurnId == null || !uploadedTurnIds.has(completedTurnId)) {
           await postTurn(task, sessionMeta, { rolloutFile: input.transcript_path, options });
           if (completedTurnId != null) {

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -3,6 +3,7 @@ import { Client, RunTreeConfig, RunTree } from "langsmith";
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import * as os from "node:os";
 import { findLast } from "./utils/findLast.js";
 import { loadUploadedTurnIds, markTurnUploaded } from "./sidecar.js";
 import { codingAgentMetadata, resolveGitInfo } from "./metadata.js";
@@ -28,15 +29,46 @@ async function loadSession(name: string) {
   return result;
 }
 
-// Rollout files are stored at `<sessionsRoot>/YYYY/MM/DD/rollout-<ts>-<threadId>.jsonl`.
-// Given the path of the parent rollout file we walk up to the sessions root and
-// recursively look for a file whose name ends with the subagent's thread id.
+// spawn_agent's output carries the child thread id as `agent_id` (string or object).
+function extractSpawnedAgentId(output: unknown): string | undefined {
+  let obj: unknown = output;
+  if (typeof output === "string") {
+    try {
+      obj = JSON.parse(output);
+    } catch {
+      return undefined;
+    }
+  }
+  if (obj != null && typeof obj === "object") {
+    const id = (obj as { agent_id?: unknown }).agent_id;
+    if (typeof id === "string") return id;
+  }
+  return undefined;
+}
+
+// Anchor at the real sessions root (override, nearest `sessions` ancestor, or
+// ~/.codex/sessions) rather than a fragile fixed depth.
+function resolveSessionsRoot(parentFileName: string, sessionsRoot?: string): string {
+  if (sessionsRoot) return sessionsRoot;
+
+  let dir = path.dirname(path.resolve(parentFileName));
+  while (true) {
+    if (path.basename(dir) === "sessions") return dir;
+    const up = path.dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return path.join(os.homedir(), ".codex", "sessions");
+}
+
+// Recursively find the rollout file whose name ends with the subagent's thread id.
 async function findRolloutFileByThreadId(
   parentFileName: string,
   threadId: string,
+  sessionsRoot?: string,
 ): Promise<string | undefined> {
   const suffix = `-${threadId}.jsonl`;
-  const root = path.resolve(path.dirname(parentFileName), "../../..");
+  const root = resolveSessionsRoot(parentFileName, sessionsRoot);
 
   async function walk(dir: string): Promise<string | undefined> {
     let entries: import("node:fs").Dirent[];
@@ -284,6 +316,7 @@ async function postTurn(
       projectName?: string;
       metadata?: Record<string, unknown>;
       replicas?: RunTreeConfig["replicas"];
+      sessionsRoot?: string;
 
       parentRunTree?: RunTree;
       debugNow?: { now: number; startTime: number };
@@ -526,7 +559,11 @@ async function postTurn(
     }
 
     for (const subagentThread of subagentThreads ?? []) {
-      const subagentFile = await findRolloutFileByThreadId(rolloutFile, subagentThread);
+      const subagentFile = await findRolloutFileByThreadId(
+        rolloutFile,
+        subagentThread,
+        options?.sessionsRoot,
+      );
 
       if (subagentFile == null) {
         continue;
@@ -579,6 +616,10 @@ export async function convertToRunTree(
   // 1-based native turn index within this thread; incremented per task_started.
   let turnNumber = 0;
 
+  // spawn_agent call_id → its AI message, so the child id from the matching
+  // function_call_output attaches there.
+  const spawnAgentMessages = new Map<string, { subagentThreads: string[] }>();
+
   // Turns that have already been uploaded in a previous hook invocation for the
   // same rollout file. Used to avoid replaying completed turns when the user
   // resumes or continues a conversation.
@@ -616,6 +657,17 @@ export async function convertToRunTree(
         subagentThreads: [],
       };
       task.messages.push(message);
+
+      // multi_agent_v1 discovery: attach the child id from spawn_agent's output.
+      if (payload.type === "function_call" && payload.name === "spawn_agent") {
+        spawnAgentMessages.set(payload.call_id, message);
+      } else if (
+        payload.type === "function_call_output" &&
+        spawnAgentMessages.has(payload.call_id)
+      ) {
+        const childId = extractSpawnedAgentId(payload.output);
+        if (childId != null) spawnAgentMessages.get(payload.call_id)?.subagentThreads.push(childId);
+      }
 
       // Only capture the user message after we retrieved to turn context,
       // since <environment_context /> is being sent as user message

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -286,8 +286,6 @@ async function postTurn(
       replicas?: RunTreeConfig["replicas"];
 
       parentRunTree?: RunTree;
-      // Root conversation thread_id, propagated to subagent runs for grouping.
-      threadId?: string;
       debugNow?: { now: number; startTime: number };
     };
   },
@@ -356,8 +354,11 @@ async function postTurn(
 
   const git = await resolveGitInfo(cwd, sessionMeta?.git);
 
-  // thread_id groups the whole conversation; subagents inherit the root's.
-  const conversationThreadId = options?.threadId ?? sessionMeta?.session_id;
+  const isSubagent = sessionMeta?.is_subagent === true;
+
+  // Subagents are separate rollouts; group under the parent thread, not their own.
+  const conversationThreadId =
+    (isSubagent ? sessionMeta?.parent_thread_id : undefined) ?? sessionMeta?.session_id;
 
   // coding-agent-v1 base contract, stamped onto every run below.
   const base = codingAgentMetadata({
@@ -369,8 +370,6 @@ async function postTurn(
     git,
     sandboxType,
   });
-
-  const isSubagent = sessionMeta?.is_subagent === true;
 
   // Scope-restricted keys: approval_policy on root only, ls_subagent_* on
   // subagent only. Set undefined elsewhere to override inherited values.
@@ -544,7 +543,7 @@ async function postTurn(
 
       await convertToRunTree(
         { transcript_path: subagentFile, turn_id: lastTurnId },
-        { ...options, parentRunTree: parent, threadId: conversationThreadId, debugNow },
+        { ...options, parentRunTree: parent, debugNow },
       );
     }
   }
@@ -559,8 +558,6 @@ export async function convertToRunTree(
     replicas?: RunTreeConfig["replicas"];
     projectName?: string;
     sessionsRoot?: string;
-    // Root conversation thread_id, propagated to subagent runs for grouping.
-    threadId?: string;
     debugNow?: { now: number; startTime: number };
   },
 ) {
@@ -604,6 +601,7 @@ export async function convertToRunTree(
         cwd: payload.cwd,
         git: payload.git,
         is_subagent: threadSpawn != null,
+        parent_thread_id: threadSpawn?.parent_thread_id ?? undefined,
         agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? undefined,
         agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? undefined,
       };

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -1057,6 +1057,8 @@ export type Session = {
   git?: GitInfo;
   // Derived from `session_meta.source` (root vs spawned subagent thread).
   is_subagent?: boolean;
+  // Parent (root, for depth-1) thread that this subagent groups under.
+  parent_thread_id?: string;
   agent_role?: string;
   agent_nickname?: string;
 };

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -18,6 +18,19 @@ export type GitInfo = {
   repository_url?: string;
 };
 
+// `session_meta.source` for a spawned subagent thread.
+export type SubagentSource = {
+  subagent: {
+    thread_spawn: {
+      parent_thread_id?: string;
+      depth?: number;
+      agent_path?: string | null;
+      agent_nickname?: string | null;
+      agent_role?: string | null;
+    };
+  };
+};
+
 export type SessionMetaPayload = {
   id: string;
   forked_from_id?: string;
@@ -1040,6 +1053,12 @@ export type Session = {
   model_provider: string | undefined;
   base_instructions: string | undefined;
   cli_version: string;
+  cwd?: string;
+  git?: GitInfo;
+  // Derived from `session_meta.source` (root vs spawned subagent thread).
+  is_subagent?: boolean;
+  agent_role?: string;
+  agent_nickname?: string;
 };
 
 export type TokenCount = {
@@ -1066,6 +1085,8 @@ export type MergedMessage<TMessage> = {
 
 export type Task = {
   turnId: { id: string; timestamp: number } | undefined;
+  // 1-based native turn index within the thread.
+  turnNumber: number | undefined;
   messages: AggregateMessage<ResponseItem>[];
   userMessageIndex: number | undefined;
   context: { model: string; [key: string]: unknown } | undefined;

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -348,7 +348,7 @@ describe("coding-agent-v1 contract", () => {
 
     expect(root.repository_url).toBe("https://github.com/langchain-ai/langsmith-codex-plugins");
     expect(root.repository_provider).toBe("github");
-    expect(root.repository_name).toBe("langsmith-codex-plugins");
+    expect(root.repository_name).toBe("langchain-ai/langsmith-codex-plugins");
     expect(root.git_branch).toBe("main");
     expect(root.git_commit_sha).toBe(GIT.commit_hash);
     expect(root.cwd).toBe(CWD);

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -135,7 +135,8 @@ function parentTranscript(): string {
   ].join("\n");
 }
 
-// Subagent thread spawned by the root turn; `source.subagent` marks it.
+// Separate subagent rollout (its own session/hook). source.subagent.thread_spawn
+// carries parent_thread_id, matching real Codex serialization (role null).
 function subagentTranscript(): string {
   return [
     line("session_meta", {
@@ -151,12 +152,12 @@ function subagentTranscript(): string {
             depth: 1,
             agent_path: null,
             agent_nickname: "Harvey",
-            agent_role: "researcher",
+            agent_role: null,
           },
         },
       },
       agent_nickname: "Harvey",
-      agent_role: "researcher",
+      agent_role: null,
       model_provider: "openai",
       git: GIT,
       base_instructions: { text: "You are a Codex subagent." },
@@ -187,33 +188,36 @@ function subagentTranscript(): string {
 
 type RunType = "root" | "llm" | "tool" | "subagent";
 
-function classify(run: { run_type?: string; parent_run_id?: string | null }): RunType | undefined {
-  if (run.run_type === "llm") return "llm";
-  if (run.run_type === "tool") return "tool";
-  if (run.run_type === "chain") return run.parent_run_id ? "subagent" : "root";
-  return undefined;
+// Separate session trees so the root trace can't recurse into the subagent;
+// each is traced by its own hook (model B).
+const ROOT_DIR = "/root/.codex/sessions/2026/06/01";
+const SUB_DIR = "/sub/.codex/sessions/2026/06/01";
+
+async function traceFile(transcriptPath: string, turnId: string) {
+  const { client, callSpy } = mockClient();
+  await convertToRunTree(
+    { transcript_path: transcriptPath, turn_id: turnId },
+    { client, projectName: "codex" },
+  );
+  await client.awaitPendingTraceBatches();
+  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+  return Object.values(tree.data) as Array<{
+    run_type?: string;
+    extra?: { metadata?: Record<string, unknown> };
+  }>;
 }
 
 async function buildRuns() {
-  const { client, callSpy } = mockClient();
-
-  const baseDir = "/home/codex-user/.codex/sessions/2026/06/01";
   vol.fromJSON({
-    [path.join(baseDir, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
-    [path.join(baseDir, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
+    [path.join(ROOT_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
+    [path.join(SUB_DIR, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
   });
 
-  await convertToRunTree(
-    {
-      transcript_path: path.join(baseDir, `rollout-parent-${PARENT_THREAD}.jsonl`),
-      turn_id: PARENT_TURN,
-    },
-    { client, projectName: "codex" },
+  const rootRuns = await traceFile(
+    path.join(ROOT_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`),
+    PARENT_TURN,
   );
-
-  await client.awaitPendingTraceBatches();
-
-  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+  const subRuns = await traceFile(path.join(SUB_DIR, `rollout-sub-${SUB_THREAD}.jsonl`), SUB_TURN);
 
   const byType: Record<RunType, Array<Record<string, unknown>>> = {
     root: [],
@@ -222,14 +226,16 @@ async function buildRuns() {
     subagent: [],
   };
 
-  for (const run of Object.values(tree.data) as Array<{
-    run_type?: string;
-    parent_run_id?: string | null;
-    extra?: { metadata?: Record<string, unknown> };
-  }>) {
-    const type = classify(run);
-    if (type == null) continue;
-    byType[type].push(run.extra?.metadata ?? {});
+  // The root trace's top chain is the root; the subagent trace's is the subagent.
+  for (const run of rootRuns) {
+    if (run.run_type === "chain") byType.root.push(run.extra?.metadata ?? {});
+    else if (run.run_type === "llm") byType.llm.push(run.extra?.metadata ?? {});
+    else if (run.run_type === "tool") byType.tool.push(run.extra?.metadata ?? {});
+  }
+  for (const run of subRuns) {
+    if (run.run_type === "chain") byType.subagent.push(run.extra?.metadata ?? {});
+    else if (run.run_type === "llm") byType.llm.push(run.extra?.metadata ?? {});
+    else if (run.run_type === "tool") byType.tool.push(run.extra?.metadata ?? {});
   }
 
   return byType;
@@ -302,10 +308,10 @@ describe("coding-agent-v1 contract", () => {
       }
     }
 
-    // ls_subagent_* — subagent only.
+    // ls_subagent_* — subagent only. type falls back from null role to nickname.
     for (const meta of byType.subagent) {
       expect(meta.ls_subagent_id).toBe(SUB_THREAD);
-      expect(meta.ls_subagent_type).toBe("researcher");
+      expect(meta.ls_subagent_type).toBe("Harvey");
     }
     for (const type of ["root", "llm", "tool"] as const) {
       for (const meta of byType[type]) {
@@ -354,9 +360,10 @@ describe("coding-agent-v1 contract", () => {
     expect(root.ls_subagent_type).toBeUndefined();
     expect(root.codex_cli_version).toBe(CLI_VERSION);
 
-    // Subagent groups under the ROOT thread_id, keeps its own id + turn marker.
+    // Independently-traced subagent groups under the ROOT thread_id, not its own.
     const sub = byType.subagent[0];
     expect(sub.thread_id).toBe(PARENT_THREAD);
+    expect(sub.thread_id).not.toBe(SUB_THREAD);
     expect(sub.ls_subagent_id).toBe(SUB_THREAD);
     expect(sub.turn_id).toBe(SUB_TURN);
     expect(sub.turn_number).toBe(1);

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -181,7 +181,7 @@ function subagentTranscript(): string {
 type RunType = "root" | "llm" | "tool" | "subagent";
 
 // Real emission path: parent + child co-located under a sessions/ tree. Only the
-// PARENT is traced; the child must be DISCOVERED via collab_* and recursed into.
+// PARENT is traced; the child must be DISCOVERED via spawn_agent and recursed into.
 const BASE_DIR = "/home/codex-user/.codex/sessions/2026/06/01";
 
 function classify(run: { run_type?: string; parent_run_id?: string | null }): RunType | undefined {
@@ -230,7 +230,7 @@ async function buildRuns() {
 
 describe("coding-agent-v1 contract", () => {
   // The live failure: the subagent rollout was never emitted. Tracing the PARENT
-  // alone must DISCOVER the child (via collab_*) and post it under the root thread.
+  // alone must DISCOVER the child (via spawn_agent) and post it under the root thread.
   it("discovers and emits the subagent from the parent trace alone", async () => {
     const byType = await buildRuns();
     expect(byType.subagent.length, "subagent runs discovered").toBeGreaterThanOrEqual(1);
@@ -239,6 +239,38 @@ describe("coding-agent-v1 contract", () => {
       expect(meta.ls_subagent_id).toBe(SUB_THREAD);
       expect(meta.ls_subagent_type).toBe("Harvey");
     }
+  });
+
+  // LLM/tool spans come from the inter-event timeline, not a single instant.
+  it("assigns non-zero durations from gapped timestamps", async () => {
+    const { client, callSpy } = mockClient();
+    vol.fromJSON({
+      [path.join(BASE_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
+      [path.join(BASE_DIR, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
+    });
+    await convertToRunTree(
+      {
+        transcript_path: path.join(BASE_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`),
+        turn_id: PARENT_TURN,
+      },
+      { client, projectName: "codex" },
+    );
+    await client.awaitPendingTraceBatches();
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+
+    const toMs = (v: unknown) => (typeof v === "number" ? v : Date.parse(String(v)));
+    const runs = Object.values(tree.data) as Array<{
+      run_type?: string;
+      start_time?: unknown;
+      end_time?: unknown;
+    }>;
+    const dur = (r: { start_time?: unknown; end_time?: unknown }) =>
+      toMs(r.end_time) - toMs(r.start_time);
+
+    const llm = runs.find((r) => r.run_type === "llm");
+    const tool = runs.find((r) => r.run_type === "tool");
+    expect(dur(llm!), "llm duration").toBeGreaterThan(0);
+    expect(dur(tool!), "tool duration").toBeGreaterThan(0);
   });
 
   it("emits the required contract keys on every run type", async () => {

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -104,26 +104,18 @@ function parentTranscript(): string {
       call_id: "call_exec_1",
       output: "/Users/dev",
     }),
+    // Live schema: spawn_agent's output carries the child id as `agent_id`
+    // (no collab_* event) — the real discovery trigger.
     line("response_item", {
       type: "function_call",
       name: "spawn_agent",
       call_id: "call_spawn_1",
-      arguments: JSON.stringify({ message: "do research" }),
-    }),
-    line("event_msg", {
-      type: "collab_agent_spawn_end",
-      call_id: "call_spawn_1",
-      sender_thread_id: PARENT_THREAD,
-      new_thread_id: SUB_THREAD,
-      prompt: "do research",
-      model: "gpt-5.4",
-      reasoning_effort: null,
-      status: "ok",
+      arguments: JSON.stringify({ agent_type: "explorer", message: "do research" }),
     }),
     line("response_item", {
       type: "function_call_output",
       call_id: "call_spawn_1",
-      output: `spawned ${SUB_THREAD}`,
+      output: JSON.stringify({ agent_id: SUB_THREAD, nickname: "Harvey" }),
     }),
     line("response_item", {
       type: "message",
@@ -188,36 +180,35 @@ function subagentTranscript(): string {
 
 type RunType = "root" | "llm" | "tool" | "subagent";
 
-// Separate session trees so the root trace can't recurse into the subagent;
-// each is traced by its own hook (model B).
-const ROOT_DIR = "/root/.codex/sessions/2026/06/01";
-const SUB_DIR = "/sub/.codex/sessions/2026/06/01";
+// Real emission path: parent + child co-located under a sessions/ tree. Only the
+// PARENT is traced; the child must be DISCOVERED via collab_* and recursed into.
+const BASE_DIR = "/home/codex-user/.codex/sessions/2026/06/01";
 
-async function traceFile(transcriptPath: string, turnId: string) {
-  const { client, callSpy } = mockClient();
-  await convertToRunTree(
-    { transcript_path: transcriptPath, turn_id: turnId },
-    { client, projectName: "codex" },
-  );
-  await client.awaitPendingTraceBatches();
-  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
-  return Object.values(tree.data) as Array<{
-    run_type?: string;
-    extra?: { metadata?: Record<string, unknown> };
-  }>;
+function classify(run: { run_type?: string; parent_run_id?: string | null }): RunType | undefined {
+  if (run.run_type === "llm") return "llm";
+  if (run.run_type === "tool") return "tool";
+  if (run.run_type === "chain") return run.parent_run_id ? "subagent" : "root";
+  return undefined;
 }
 
 async function buildRuns() {
+  const { client, callSpy } = mockClient();
+
   vol.fromJSON({
-    [path.join(ROOT_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
-    [path.join(SUB_DIR, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
+    [path.join(BASE_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
+    [path.join(BASE_DIR, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
   });
 
-  const rootRuns = await traceFile(
-    path.join(ROOT_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`),
-    PARENT_TURN,
+  await convertToRunTree(
+    {
+      transcript_path: path.join(BASE_DIR, `rollout-parent-${PARENT_THREAD}.jsonl`),
+      turn_id: PARENT_TURN,
+    },
+    { client, projectName: "codex" },
   );
-  const subRuns = await traceFile(path.join(SUB_DIR, `rollout-sub-${SUB_THREAD}.jsonl`), SUB_TURN);
+  await client.awaitPendingTraceBatches();
+
+  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
 
   const byType: Record<RunType, Array<Record<string, unknown>>> = {
     root: [],
@@ -225,23 +216,31 @@ async function buildRuns() {
     tool: [],
     subagent: [],
   };
-
-  // The root trace's top chain is the root; the subagent trace's is the subagent.
-  for (const run of rootRuns) {
-    if (run.run_type === "chain") byType.root.push(run.extra?.metadata ?? {});
-    else if (run.run_type === "llm") byType.llm.push(run.extra?.metadata ?? {});
-    else if (run.run_type === "tool") byType.tool.push(run.extra?.metadata ?? {});
-  }
-  for (const run of subRuns) {
-    if (run.run_type === "chain") byType.subagent.push(run.extra?.metadata ?? {});
-    else if (run.run_type === "llm") byType.llm.push(run.extra?.metadata ?? {});
-    else if (run.run_type === "tool") byType.tool.push(run.extra?.metadata ?? {});
+  for (const run of Object.values(tree.data) as Array<{
+    run_type?: string;
+    parent_run_id?: string | null;
+    extra?: { metadata?: Record<string, unknown> };
+  }>) {
+    const type = classify(run);
+    if (type != null) byType[type].push(run.extra?.metadata ?? {});
   }
 
   return byType;
 }
 
 describe("coding-agent-v1 contract", () => {
+  // The live failure: the subagent rollout was never emitted. Tracing the PARENT
+  // alone must DISCOVER the child (via collab_*) and post it under the root thread.
+  it("discovers and emits the subagent from the parent trace alone", async () => {
+    const byType = await buildRuns();
+    expect(byType.subagent.length, "subagent runs discovered").toBeGreaterThanOrEqual(1);
+    for (const meta of byType.subagent) {
+      expect(meta.thread_id).toBe(PARENT_THREAD);
+      expect(meta.ls_subagent_id).toBe(SUB_THREAD);
+      expect(meta.ls_subagent_type).toBe("Harvey");
+    }
+  });
+
   it("emits the required contract keys on every run type", async () => {
     const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
     const validator = JSON.parse(

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vol } from "memfs";
+import * as path from "node:path";
+
+import { convertToRunTree } from "../src/trace.js";
+import { mockClient } from "./utils/mock_client.js";
+import { getAssumedTreeFromCalls } from "./utils/tree.js";
+
+// Fixture transcripts live in memfs; validator.json is read via the real fs.
+vi.mock("node:fs/promises", async () => {
+  const { fs } = await import("memfs");
+  return fs.promises;
+});
+vi.mock("node:fs", async () => {
+  const { fs } = await import("memfs");
+  return fs;
+});
+
+beforeEach(() => vol.reset());
+afterEach(() => vi.unstubAllEnvs());
+
+// ── Fixture identities ──────────────────────────────────────────────────────
+const PARENT_THREAD = "0199aaaa-1111-2222-3333-parentthread0";
+const PARENT_TURN = "0199aaaa-tttt-0001";
+const SUB_THREAD = "0199bbbb-4444-5555-6666-subthread0001";
+const SUB_TURN = "0199bbbb-tttt-0002";
+
+const CWD = "/Users/dev/langsmith-codex-plugins";
+const GIT = {
+  commit_hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+  branch: "main",
+  repository_url: "https://github.com/langchain-ai/langsmith-codex-plugins.git",
+};
+const CLI_VERSION = "0.123.0";
+
+// Build-time injected plugin version (see vitest.config.ts / tsdown.config.ts).
+declare const __LS_INTEGRATION_VERSION__: string;
+const INTEGRATION_VERSION = __LS_INTEGRATION_VERSION__;
+
+let clock = Date.parse("2026-06-01T12:00:00.000Z");
+function ts(): string {
+  clock += 1000;
+  return new Date(clock).toISOString();
+}
+
+function line(type: string, payload: Record<string, unknown>): string {
+  return JSON.stringify({ timestamp: ts(), type, payload });
+}
+
+const TOKEN_INFO = {
+  total_token_usage: {
+    input_tokens: 100,
+    output_tokens: 20,
+    total_tokens: 120,
+    cached_input_tokens: 0,
+    reasoning_output_tokens: 0,
+  },
+  last_token_usage: {
+    input_tokens: 100,
+    output_tokens: 20,
+    total_tokens: 120,
+    cached_input_tokens: 0,
+    reasoning_output_tokens: 0,
+  },
+  model_context_window: 200000,
+};
+
+// Root turn that runs one plain tool (exec_command) and spawns one subagent.
+function parentTranscript(): string {
+  return [
+    line("session_meta", {
+      id: PARENT_THREAD,
+      timestamp: ts(),
+      cwd: CWD,
+      originator: "codex-tui",
+      cli_version: CLI_VERSION,
+      source: "cli",
+      model_provider: "openai",
+      git: GIT,
+      base_instructions: { text: "You are Codex." },
+    }),
+    line("event_msg", { type: "task_started", turn_id: PARENT_TURN }),
+    line("turn_context", {
+      turn_id: PARENT_TURN,
+      cwd: CWD,
+      approval_policy: "on-request",
+      sandbox_policy: { type: "workspace-write", network_access: false },
+      model: "gpt-5.4",
+      summary: "none",
+    }),
+    line("response_item", {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Run a subagent" }],
+    }),
+    line("response_item", {
+      type: "function_call",
+      name: "exec_command",
+      call_id: "call_exec_1",
+      arguments: JSON.stringify({ cmd: "pwd" }),
+    }),
+    line("response_item", {
+      type: "function_call_output",
+      call_id: "call_exec_1",
+      output: "/Users/dev",
+    }),
+    line("response_item", {
+      type: "function_call",
+      name: "spawn_agent",
+      call_id: "call_spawn_1",
+      arguments: JSON.stringify({ message: "do research" }),
+    }),
+    line("event_msg", {
+      type: "collab_agent_spawn_end",
+      call_id: "call_spawn_1",
+      sender_thread_id: PARENT_THREAD,
+      new_thread_id: SUB_THREAD,
+      prompt: "do research",
+      model: "gpt-5.4",
+      reasoning_effort: null,
+      status: "ok",
+    }),
+    line("response_item", {
+      type: "function_call_output",
+      call_id: "call_spawn_1",
+      output: `spawned ${SUB_THREAD}`,
+    }),
+    line("response_item", {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "All done" }],
+    }),
+    line("event_msg", { type: "token_count", info: TOKEN_INFO }),
+    line("event_msg", { type: "task_complete", turn_id: PARENT_TURN }),
+  ].join("\n");
+}
+
+// Subagent thread spawned by the root turn; `source.subagent` marks it.
+function subagentTranscript(): string {
+  return [
+    line("session_meta", {
+      id: SUB_THREAD,
+      timestamp: ts(),
+      cwd: CWD,
+      originator: "codex-tui",
+      cli_version: CLI_VERSION,
+      source: {
+        subagent: {
+          thread_spawn: {
+            parent_thread_id: PARENT_THREAD,
+            depth: 1,
+            agent_path: null,
+            agent_nickname: "Harvey",
+            agent_role: "researcher",
+          },
+        },
+      },
+      agent_nickname: "Harvey",
+      agent_role: "researcher",
+      model_provider: "openai",
+      git: GIT,
+      base_instructions: { text: "You are a Codex subagent." },
+    }),
+    line("event_msg", { type: "task_started", turn_id: SUB_TURN }),
+    line("turn_context", {
+      turn_id: SUB_TURN,
+      cwd: CWD,
+      approval_policy: "on-request",
+      sandbox_policy: { type: "workspace-write", network_access: false },
+      model: "gpt-5.4",
+      summary: "none",
+    }),
+    line("response_item", {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "do research" }],
+    }),
+    line("response_item", {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "research done" }],
+    }),
+    line("event_msg", { type: "token_count", info: TOKEN_INFO }),
+    line("event_msg", { type: "task_complete", turn_id: SUB_TURN }),
+  ].join("\n");
+}
+
+type RunType = "root" | "llm" | "tool" | "subagent";
+
+function classify(run: { run_type?: string; parent_run_id?: string | null }): RunType | undefined {
+  if (run.run_type === "llm") return "llm";
+  if (run.run_type === "tool") return "tool";
+  if (run.run_type === "chain") return run.parent_run_id ? "subagent" : "root";
+  return undefined;
+}
+
+async function buildRuns() {
+  const { client, callSpy } = mockClient();
+
+  const baseDir = "/home/codex-user/.codex/sessions/2026/06/01";
+  vol.fromJSON({
+    [path.join(baseDir, `rollout-parent-${PARENT_THREAD}.jsonl`)]: parentTranscript(),
+    [path.join(baseDir, `rollout-sub-${SUB_THREAD}.jsonl`)]: subagentTranscript(),
+  });
+
+  await convertToRunTree(
+    {
+      transcript_path: path.join(baseDir, `rollout-parent-${PARENT_THREAD}.jsonl`),
+      turn_id: PARENT_TURN,
+    },
+    { client, projectName: "codex" },
+  );
+
+  await client.awaitPendingTraceBatches();
+
+  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+
+  const byType: Record<RunType, Array<Record<string, unknown>>> = {
+    root: [],
+    llm: [],
+    tool: [],
+    subagent: [],
+  };
+
+  for (const run of Object.values(tree.data) as Array<{
+    run_type?: string;
+    parent_run_id?: string | null;
+    extra?: { metadata?: Record<string, unknown> };
+  }>) {
+    const type = classify(run);
+    if (type == null) continue;
+    byType[type].push(run.extra?.metadata ?? {});
+  }
+
+  return byType;
+}
+
+describe("coding-agent-v1 contract", () => {
+  it("emits the required contract keys on every run type", async () => {
+    const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const validator = JSON.parse(
+      await realFs.readFile(path.join(__dirname, "fixtures", "validator.json"), "utf-8"),
+    ) as {
+      keys: Array<{
+        key: string;
+        appliesTo: RunType[];
+        type: "string" | "integer";
+        allowedValues: string[] | null;
+        requirement: "always" | "where_known" | "contextual";
+      }>;
+    };
+
+    const byType = await buildRuns();
+
+    // Sanity: the fixture exercises all four run types.
+    expect(byType.root.length, "root runs").toBeGreaterThanOrEqual(1);
+    expect(byType.llm.length, "llm runs").toBeGreaterThanOrEqual(1);
+    expect(byType.tool.length, "tool runs").toBeGreaterThanOrEqual(1);
+    expect(byType.subagent.length, "subagent runs").toBeGreaterThanOrEqual(1);
+
+    const checkKey = (
+      meta: Record<string, unknown>,
+      def: (typeof validator.keys)[number],
+      label: string,
+    ) => {
+      const value = meta[def.key];
+      expect(value, `${label}: ${def.key} present`).toBeDefined();
+      if (def.type === "integer") {
+        expect(Number.isInteger(value), `${label}: ${def.key} integer`).toBe(true);
+      } else {
+        expect(typeof value, `${label}: ${def.key} string`).toBe("string");
+      }
+      if (def.allowedValues != null) {
+        expect(def.allowedValues, `${label}: ${def.key} allowed`).toContain(value);
+      }
+    };
+
+    // The fixture provides every where_known value, so all must be present.
+    const requiredDefs = validator.keys.filter(
+      (k) => k.requirement === "always" || k.requirement === "where_known",
+    );
+
+    for (const type of ["root", "llm", "tool", "subagent"] as const) {
+      for (const [idx, meta] of byType[type].entries()) {
+        const label = `${type}[${idx}]`;
+        for (const def of requiredDefs) {
+          if (!def.appliesTo.includes(type)) continue;
+          checkKey(meta, def, label);
+        }
+      }
+    }
+  });
+
+  it("scopes contextual keys to their run types", async () => {
+    const byType = await buildRuns();
+
+    // approval_policy — root only (never llm/tool/subagent).
+    for (const meta of byType.root) expect(meta.approval_policy).toBe("on-request");
+    for (const type of ["llm", "tool", "subagent"] as const) {
+      for (const meta of byType[type]) {
+        expect(meta.approval_policy, `${type} approval_policy`).toBeUndefined();
+      }
+    }
+
+    // ls_subagent_* — subagent only.
+    for (const meta of byType.subagent) {
+      expect(meta.ls_subagent_id).toBe(SUB_THREAD);
+      expect(meta.ls_subagent_type).toBe("researcher");
+    }
+    for (const type of ["root", "llm", "tool"] as const) {
+      for (const meta of byType[type]) {
+        expect(meta.ls_subagent_id, `${type} ls_subagent_id`).toBeUndefined();
+        expect(meta.ls_subagent_type, `${type} ls_subagent_type`).toBeUndefined();
+      }
+    }
+
+    // ls_tool_name — tool runs only, and only when run name differs from native.
+    for (const type of ["root", "llm", "subagent"] as const) {
+      for (const meta of byType[type]) {
+        expect(meta.ls_tool_name, `${type} ls_tool_name`).toBeUndefined();
+      }
+    }
+    for (const meta of byType.tool) {
+      if (meta.ls_tool_name !== undefined) expect(typeof meta.ls_tool_name).toBe("string");
+    }
+  });
+
+  it("maps the frozen literal values and turn markers", async () => {
+    const byType = await buildRuns();
+    const root = byType.root[0];
+
+    expect(root.ls_agent_kind).toBe("coding_agent");
+    expect(root.ls_integration).toBe("openai-codex");
+    expect(root.ls_agent_runtime).toBe("Codex");
+    expect(root.ls_trace_schema_version).toBe("coding-agent-v1");
+
+    expect(root.ls_integration_version).toBe(INTEGRATION_VERSION);
+    expect(root.ls_agent_runtime_version).toBe(CLI_VERSION);
+
+    expect(root.thread_id).toBe(PARENT_THREAD);
+    expect(root.turn_id).toBe(PARENT_TURN);
+    expect(root.turn_number).toBe(1);
+
+    expect(root.repository_url).toBe("https://github.com/langchain-ai/langsmith-codex-plugins");
+    expect(root.repository_provider).toBe("github");
+    expect(root.repository_name).toBe("langsmith-codex-plugins");
+    expect(root.git_branch).toBe("main");
+    expect(root.git_commit_sha).toBe(GIT.commit_hash);
+    expect(root.cwd).toBe(CWD);
+    expect(root.sandbox_type).toBe("workspace-write");
+
+    // Compat alias; never surfaces ls_subagent_type on the root.
+    expect(root.ls_agent_type).toBe("root");
+    expect(root.ls_subagent_type).toBeUndefined();
+    expect(root.codex_cli_version).toBe(CLI_VERSION);
+
+    // Subagent groups under the ROOT thread_id, keeps its own id + turn marker.
+    const sub = byType.subagent[0];
+    expect(sub.thread_id).toBe(PARENT_THREAD);
+    expect(sub.ls_subagent_id).toBe(SUB_THREAD);
+    expect(sub.turn_id).toBe(SUB_TURN);
+    expect(sub.turn_number).toBe(1);
+    expect(sub.ls_agent_type).toBe("subagent");
+
+    // Every run shares the root thread_id; turn markers are per-turn.
+    for (const meta of [...byType.llm, ...byType.tool]) {
+      expect(meta.thread_id).toBe(PARENT_THREAD);
+    }
+    const parentChildren = [...byType.llm, ...byType.tool].filter((m) => m.turn_id === PARENT_TURN);
+    expect(parentChildren.length).toBeGreaterThanOrEqual(3);
+    for (const meta of parentChildren) expect(meta.turn_number).toBe(1);
+
+    // Subagent-owned llm/tool runs carry the subagent's own turn marker.
+    const subChildren = [...byType.llm, ...byType.tool].filter((m) => m.turn_id === SUB_TURN);
+    expect(subChildren.length).toBeGreaterThanOrEqual(1);
+    for (const meta of subChildren) {
+      expect(meta.turn_id).toBe(SUB_TURN);
+      expect(meta.turn_number).toBe(1);
+    }
+  });
+});

--- a/plugins/tracing/test/fixtures/validator.json
+++ b/plugins/tracing/test/fixtures/validator.json
@@ -1,0 +1,241 @@
+{
+  "schemaVersion": "coding-agent-v1",
+  "description": "Machine-readable contract for LangSmith coding-agent trace metadata. Set on run.extra.metadata. 'requirement' tiers: always = on every run; where_known = required when the runtime exposes the value, omit otherwise; contextual = optional. runTypes: root | llm | tool | subagent | interrupted.",
+  "integrations": ["claude-code", "openai-codex", "deepagents-code", "cursor", "pi"],
+  "runtimeNames": {
+    "claude-code": "Claude Code",
+    "openai-codex": "Codex",
+    "deepagents-code": "Deep Agents Code",
+    "cursor": "Cursor",
+    "pi": "Pi"
+  },
+  "keys": [
+    {
+      "key": "ls_agent_kind",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["coding_agent"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_integration",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["claude-code", "openai-codex", "deepagents-code", "cursor", "pi"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_agent_runtime",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["Claude Code", "Codex", "Deep Agents Code", "Cursor", "Pi"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "thread_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_trace_schema_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["coding-agent-v1"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_integration_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "Bundled plugins (cursor, claude-code, pi) must inject at build time via esbuild define; do not require('./package.json')."
+    },
+    {
+      "key": "ls_agent_runtime_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "turn_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "At least one of turn_id / turn_number is required wherever the runtime exposes turns."
+    },
+    {
+      "key": "turn_number",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "integer",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "1-based. Pi source is 0-based turnIndex -> emit turnIndex + 1."
+    },
+    {
+      "key": "repository_url",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "repository_provider",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "suggestedValues": ["github", "gitlab", "bitbucket", "other"],
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "repository_name",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "git_branch",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "git_commit_sha",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "cwd",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "user_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Stable, pseudonymous; preferred over local_username."
+    },
+    {
+      "key": "local_username",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "PII-sensitive, backward-compatible."
+    },
+    {
+      "key": "user_email",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Provisional / PII. Emit where known, omit otherwise; may be scrapped later."
+    },
+    {
+      "key": "sandbox_type",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "approval_policy",
+      "appliesTo": ["root", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Permission mode / policy for the turn. Root + interrupted only."
+    },
+    {
+      "key": "ls_subagent_id",
+      "appliesTo": ["subagent"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_subagent_type",
+      "appliesTo": ["subagent"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Subagent runs only. Do NOT emit on root runs (e.g. do not copy claude-code's old ls_agent_type='root' here)."
+    },
+    {
+      "key": "ls_tool_name",
+      "appliesTo": ["tool"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Tool runs only; emit when it differs from the run name. Pass-through native name — no cross-agent taxonomy normalization."
+    }
+  ],
+  "preserveExistingOnModelAndToolRuns": [
+    "ls_provider",
+    "ls_model_name",
+    "ls_invocation_params",
+    "usage_metadata"
+  ],
+  "perIntegrationSources": {
+    "claude-code": {
+      "thread_id": "session_id (hook payload)",
+      "turn_id": "promptId (transcript, native)",
+      "turn_number": "turn_count"
+    },
+    "openai-codex": {
+      "thread_id": "thread_id",
+      "turn_id": "turn_id",
+      "turn_number": "native"
+    },
+    "cursor": {
+      "thread_id": "conversation_id",
+      "turn_id": "generation_id",
+      "turn_number": "turnNum"
+    },
+    "pi": {
+      "thread_id": "ctx.sessionManager.getSessionId()",
+      "turn_id": "none -> use turnIndex as turn_number",
+      "turn_number": "turnIndex (0-based) + 1"
+    },
+    "deepagents-code": {
+      "thread_id": "configurable.thread_id",
+      "turn_id": "add — uuid4 / msg-id per prompt",
+      "turn_number": "add — counter on session_state"
+    }
+  }
+}

--- a/plugins/tracing/test/fixtures/worked-examples.json
+++ b/plugins/tracing/test/fixtures/worked-examples.json
@@ -1,0 +1,138 @@
+{
+  "_comment": "Copy-pasteable worked examples of run.extra.metadata for coding-agent-v1. Uses claude-code as the reference integration. Identity block (ls_agent_kind, ls_integration, ls_agent_runtime, thread_id, ls_trace_schema_version) + versions + turn + repo/git/cwd are emitted by ONE shared helper and merged onto EVERY run. Child runs do NOT inherit parent metadata in LangSmith — the helper must stamp each createChild/run.",
+
+  "root": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+    "approval_policy": "acceptEdits"
+  },
+
+  "llm": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_provider": "anthropic",
+    "ls_model_name": "claude-opus-4-8",
+    "ls_invocation_params": { "max_tokens": 8192, "temperature": 1 },
+    "usage_metadata": { "input_tokens": 12873, "output_tokens": 412, "total_tokens": 13285 }
+  },
+
+  "tool": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_tool_name": "Bash"
+  },
+
+  "subagent": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_subagent_id": "sub_4d8e1f",
+    "ls_subagent_type": "Explore"
+  },
+
+  "interrupted": {
+    "_comment": "Interrupted/cancelled turn. Same base as root, including approval_policy. turn_id/turn_number still emitted.",
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc124",
+    "turn_number": 4,
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+    "approval_policy": "acceptEdits"
+  }
+}

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -6,6 +6,10 @@ import * as path from "node:path";
 import { mockClient } from "./utils/mock_client.js";
 import { asTree, getAssumedTreeFromCalls } from "./utils/tree.js";
 
+// Build-time injected plugin version (see vitest.config.ts / tsdown.config.ts).
+declare const __LS_INTEGRATION_VERSION__: string;
+const INTEGRATION_VERSION = __LS_INTEGRATION_VERSION__;
+
 async function preloadTestFiles(options: { makeTurnIncomplete: boolean }) {
   const fs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
 
@@ -115,7 +119,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 ls_agent_runtime: "Codex",
                 ls_agent_runtime_version: "0.123.0",
                 ls_trace_schema_version: "coding-agent-v1",
-                ls_integration_version: "0.0.3",
+                ls_integration_version: INTEGRATION_VERSION,
                 ls_agent_type: "root",
                 approval_policy: "on-request",
                 cwd: "/Users/duongtat/Work/ls-codex-sample",

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -108,9 +108,18 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
               metadata: expect.objectContaining({
                 codex_cli_version: "0.123.0",
                 turn_id: "019dbc00-ede4-77c2-9e7a-b6876efeab9b",
+                turn_number: 1,
                 thread_id: "019dbc00-a3c9-7681-8e0c-73139815b4f2",
                 ls_integration: "openai-codex",
+                ls_agent_kind: "coding_agent",
+                ls_agent_runtime: "Codex",
+                ls_agent_runtime_version: "0.123.0",
+                ls_trace_schema_version: "coding-agent-v1",
+                ls_integration_version: "0.0.3",
                 ls_agent_type: "root",
+                approval_policy: "on-request",
+                cwd: "/Users/duongtat/Work/ls-codex-sample",
+                sandbox_type: "workspace-write",
                 ls_message_format: "anthropic",
                 usage_metadata: expect.objectContaining({
                   input_tokens: 71213,
@@ -744,8 +753,11 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
               extra: {
                 metadata: expect.objectContaining({
                   turn_id: "019dbc03-79eb-73b1-8c5b-f62bd0095409",
-                  thread_id: "019dbc03-79de-7d53-8196-3167d9a32762",
-                  ls_agent_type: "root",
+                  // Subagent groups under the root thread_id; keeps its own id.
+                  thread_id: "019dbc02-cc63-7893-9d13-9b24a7db0ace",
+                  ls_agent_type: "subagent",
+                  ls_subagent_id: "019dbc03-79de-7d53-8196-3167d9a32762",
+                  ls_subagent_type: "Harvey",
                   usage_metadata: expect.objectContaining({
                     input_tokens: 10744,
                     output_tokens: 20,
@@ -787,8 +799,11 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
               extra: {
                 metadata: expect.objectContaining({
                   turn_id: "019dbc03-79fa-7ee0-ad96-27e641f46607",
-                  thread_id: "019dbc03-79ee-7ee0-b40b-26920c74c524",
-                  ls_agent_type: "root",
+                  // Subagent groups under the root thread_id; keeps its own id.
+                  thread_id: "019dbc02-cc63-7893-9d13-9b24a7db0ace",
+                  ls_agent_type: "subagent",
+                  ls_subagent_id: "019dbc03-79ee-7ee0-b40b-26920c74c524",
+                  ls_subagent_type: "Leibniz",
                   usage_metadata: expect.objectContaining({
                     input_tokens: 21693,
                     output_tokens: 132,

--- a/plugins/tracing/tsdown.config.ts
+++ b/plugins/tracing/tsdown.config.ts
@@ -1,9 +1,20 @@
 import { defineConfig } from "tsdown";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+// Inject the plugin version at build time (no runtime package.json in the
+// bundle). Mirrored in vitest.config.ts.
+const pluginVersion = JSON.parse(
+  readFileSync(path.join(import.meta.dirname, ".codex-plugin", "plugin.json"), "utf-8"),
+).version as string;
 
 export default defineConfig({
   deps: {
     alwaysBundle: ["langsmith", "zod"],
     onlyBundle: false,
+  },
+  define: {
+    __LS_INTEGRATION_VERSION__: JSON.stringify(pluginVersion),
   },
   clean: true,
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+// Mirror tsdown's build-time __LS_INTEGRATION_VERSION__ define for tests.
+const pluginVersion = JSON.parse(
+  readFileSync(
+    path.join(import.meta.dirname, "plugins", "tracing", ".codex-plugin", "plugin.json"),
+    "utf-8",
+  ),
+).version as string;
+
+export default defineConfig({
+  define: {
+    __LS_INTEGRATION_VERSION__: JSON.stringify(pluginVersion),
+  },
+});


### PR DESCRIPTION
  Implements the [coding-agent-v1](https://app.notion.com/p/Coding-Agent-Trace-Metadata-Standard-coding-agent-v1-37d808527b178163a29ef4b617b6dfee) contract so that Codex traces are identifiable, groupable, and attributable with the same stable keys as the other coding-agent integrations.

  ### Changes
  - **`src/metadata.ts`** (new) — single `codingAgentMetadata()` helper returning the base contract object (identity literals + where-known keys + compat aliases), omitting any key whose value is unknown. Includes `parseRepository()` and `resolveGitInfo()` (prefers rollout `session_meta.git`, falls back to git CLI, cached per cwd).
  - **Stamped onto every run site** (`src/trace.ts`) — root, LLM, tool, subagent, and interrupted turns. Base is built once per turn and merged at each run; scope-restricted keys are explicitly nulled on children (langsmith `createChild` propagates parent metadata, so omission alone isn't enough).
  - **New keys**: `ls_agent_kind`, `ls_agent_runtime` (`Codex`), `ls_agent_runtime_version` (from `codex_cli_version`), `ls_integration_version`, `ls_trace_schema_version`, `turn_number`, `repository_url` / `repository_provider` / `repository_name`, `git_branch`, `git_commit_sha`, `cwd`. (`thread_id`, `turn_id`, `sandbox_type`, `approval_policy` already emitted.)
  - **Renamed keys** (old retained + deprecated for ≥1 release): `ls_agent_type`→`ls_subagent_type` (subagent-only; never on root), `codex_cli_version`→`ls_agent_runtime_version`, `agent_id`→`ls_subagent_id`, `tool_name`→`ls_tool_name` (only when run name ≠ native tool name).
  - **Subagent grouping** — Codex subagents are separate in-process rollouts with no own Stop hook. `convertToRunTree` now records `spawn_agent` function-calls, extracts the child `agent_id` from the matching `function_call_output`, discovers the child rollout file, and emits it as a subagent chain grouped under the **parent** thread via `parent_thread_id`. Robust `resolveSessionsRoot` anchor; legacy `collab_agent_spawn_end` path kept for back-compat.
  - **Build-time version injection** (`tsdown.config.ts` defines `__LS_INTEGRATION_VERSION__` from `.codex-plugin/plugin.json`) — bundle has no runtime `package.json` (root is `0.0.0`).
  - **Contract test** (`test/contract.test.ts`) loads `validator.json` and asserts required keys, types, allowed values, and negative scoping rules per run type. Subagent fixture rebuilt to the live rollout schema (`spawn_agent` + `function_call_output{agent_id}`, no `collab_*`) with a dedicated test that the child is discovered + emitted from a parent-only trace.

  ### Testing
  Verified on real Codex traces with a per-integration validator (loads `validator.json`, classifies runs structurally, asserts contract per run type): 25/25 runs pass across root/LLM/tool/subagent, `ls_subagent_id`/`ls_subagent_type` coverage on the subagent chain, grouped under the parent thread, `ls_integration_version=0.0.5` confirming the deployed bundle. `tsc` + `oxfmt` clean, 20/20 unit tests pass.

  ### Notes
  - `user_id` / `local_username` / `user_email` omitted — Codex rollouts expose no pseudonymous user id (still flow through if supplied via `LANGSMITH_CODEX_METADATA`).
  - `ls_tool_name` is 0-coverage by design: Codex names every tool run after its native function, so the "differs from run name" condition never fires.
  - Existing model/tool-run keys (`ls_provider`, `ls_model_name`, `ls_invocation_params`, `usage_metadata`) unchanged.