### PR TITLE
fix(codex): avoid usage_metadata on parent chain runs (double-count) [LSDK-285]

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -12196,7 +12196,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			codex_cli_version: sessionMeta?.cli_version,
 			ls_agent_type: isSubagent ? "subagent" : "root",
 			ls_message_format: "anthropic",
-			usage_metadata: getUsageMetadata(task.tokenCount?.total_token_usage)
+			ls_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage)
 		} }
 	};
 	const parent = options?.parentRunTree?.createChild(parentConfig) ?? new RunTree(parentConfig);

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -12196,7 +12196,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			codex_cli_version: sessionMeta?.cli_version,
 			ls_agent_type: isSubagent ? "subagent" : "root",
 			ls_message_format: "anthropic",
-			ls_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage)
+			ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage)
 		} }
 	};
 	const parent = options?.parentRunTree?.createChild(parentConfig) ?? new RunTree(parentConfig);

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -434,7 +434,9 @@ async function postTurn(
         ls_agent_type: isSubagent ? "subagent" : "root",
         ls_message_format: "anthropic",
 
-        usage_metadata: getUsageMetadata(task.tokenCount?.total_token_usage),
+        // Non-reserved key: backend auto-aggregates child llm usage into the
+        // parent, so usage_metadata here would double-count.
+        ls_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
       },
     },
   };

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -436,7 +436,7 @@ async function postTurn(
 
         // Non-reserved key: backend auto-aggregates child llm usage into the
         // parent, so usage_metadata here would double-count.
-        ls_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
+        ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
       },
     },
   };

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -125,7 +125,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 cwd: "/Users/duongtat/Work/ls-codex-sample",
                 sandbox_type: "workspace-write",
                 ls_message_format: "anthropic",
-                usage_metadata: expect.objectContaining({
+                ls_aggregated_usage: expect.objectContaining({
                   input_tokens: 71213,
                   output_tokens: 1627,
                   total_tokens: 72840,
@@ -496,7 +496,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 ls_integration: "openai-codex",
                 ls_agent_type: "root",
                 ls_message_format: "anthropic",
-                usage_metadata: expect.objectContaining({
+                ls_aggregated_usage: expect.objectContaining({
                   input_tokens: 14243,
                   output_tokens: 262,
                   total_tokens: 14505,
@@ -624,7 +624,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 ls_integration: "openai-codex",
                 ls_agent_type: "root",
                 ls_message_format: "anthropic",
-                usage_metadata: expect.objectContaining({
+                ls_aggregated_usage: expect.objectContaining({
                   input_tokens: 84553,
                   output_tokens: 1049,
                   total_tokens: 85602,
@@ -762,7 +762,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                   ls_agent_type: "subagent",
                   ls_subagent_id: "019dbc03-79de-7d53-8196-3167d9a32762",
                   ls_subagent_type: "Harvey",
-                  usage_metadata: expect.objectContaining({
+                  ls_aggregated_usage: expect.objectContaining({
                     input_tokens: 10744,
                     output_tokens: 20,
                     total_tokens: 10764,
@@ -808,7 +808,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                   ls_agent_type: "subagent",
                   ls_subagent_id: "019dbc03-79ee-7ee0-b40b-26920c74c524",
                   ls_subagent_type: "Leibniz",
-                  usage_metadata: expect.objectContaining({
+                  ls_aggregated_usage: expect.objectContaining({
                     input_tokens: 21693,
                     output_tokens: 132,
                     total_tokens: 21825,

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -125,7 +125,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 cwd: "/Users/duongtat/Work/ls-codex-sample",
                 sandbox_type: "workspace-write",
                 ls_message_format: "anthropic",
-                ls_aggregated_usage: expect.objectContaining({
+                ls_raw_aggregated_usage: expect.objectContaining({
                   input_tokens: 71213,
                   output_tokens: 1627,
                   total_tokens: 72840,
@@ -496,7 +496,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 ls_integration: "openai-codex",
                 ls_agent_type: "root",
                 ls_message_format: "anthropic",
-                ls_aggregated_usage: expect.objectContaining({
+                ls_raw_aggregated_usage: expect.objectContaining({
                   input_tokens: 14243,
                   output_tokens: 262,
                   total_tokens: 14505,
@@ -624,7 +624,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                 ls_integration: "openai-codex",
                 ls_agent_type: "root",
                 ls_message_format: "anthropic",
-                ls_aggregated_usage: expect.objectContaining({
+                ls_raw_aggregated_usage: expect.objectContaining({
                   input_tokens: 84553,
                   output_tokens: 1049,
                   total_tokens: 85602,
@@ -762,7 +762,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                   ls_agent_type: "subagent",
                   ls_subagent_id: "019dbc03-79de-7d53-8196-3167d9a32762",
                   ls_subagent_type: "Harvey",
-                  ls_aggregated_usage: expect.objectContaining({
+                  ls_raw_aggregated_usage: expect.objectContaining({
                     input_tokens: 10744,
                     output_tokens: 20,
                     total_tokens: 10764,
@@ -808,7 +808,7 @@ it.each([{ makeTurnIncomplete: true }, { makeTurnIncomplete: false }])(
                   ls_agent_type: "subagent",
                   ls_subagent_id: "019dbc03-79ee-7ee0-b40b-26920c74c524",
                   ls_subagent_type: "Leibniz",
-                  ls_aggregated_usage: expect.objectContaining({
+                  ls_raw_aggregated_usage: expect.objectContaining({
                     input_tokens: 21693,
                     output_tokens: 132,
                     total_tokens: 21825,


### PR DESCRIPTION
The codex tracer stamped usage_metadata (the task's total_token_usage) on the root openai.codex chain run, while its LLM and tool children also carry usage. Since usage_metadata is a reserved key that the LangSmith backend automatically rolls up from child runs into the parent, the parent's totals were counted twice (inflating token counts and cost, with cache-read/cache-write tokens hit hardest).

This mirrors [the SDK fix](https://github.com/langchain-ai/langsmith-sdk/pull/3119).

Change
- trace.ts: rename the root chain's usage_metadata → ls_aggregated_usage (non-reserved), so the client-side aggregate is still available for display but the backend stops re-counting it. Leaf llm/tool runs keep usage_metadata as before.
- trace.test.ts: update the 5 existing chain-run assertions (3 root + 2 subagent) to expect ls_aggregated_usage.

Testing: npm test — 21/21 pass.