### PR TITLE
bump tracing to 0.0.6

### DIFF
--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -15210,7 +15210,7 @@ const LS_AGENT_PURPOSE = "coding";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.5";
+const LS_INTEGRATION_VERSION = "0.0.6";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }


### PR DESCRIPTION
Cuts the `0.0.6` release for everything landed since `0.0.5` (#21, #22, #23).

Bumps `plugins/tracing/.codex-plugin/plugin.json` `0.0.5 → 0.0.6` and rebuilds `dist` (only change is the injected `LS_INTEGRATION_VERSION`). The bump is required so codex's version-keyed plugin cache invalidates and users actually pick up the new bundle — a same-version rebuild wouldn't refresh cached installs.

Verification: `pnpm test` (33 passing), `tsc` clean, `dist` diff is version-only so `lint:dist` reproduces it.