### PR TITLE
fix: classify Codex turn interruptions

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -15937,10 +15937,13 @@ async function convertToRunTree(input, options) {
 			}
 			if (payload.type === "turn_aborted") {
 				task ??= createTask();
-				task.isErrorInterrupt = payload.reason === "interrupted";
 				const explicitError = formatError(payload.error);
 				if (explicitError != null) task.error = explicitError;
-				else if (task.error == null && payload.reason !== "review_ended") task.error = payload.reason === "interrupted" ? "Turn interrupted" : `Turn aborted: ${payload.reason}`;
+				else if (task.error == null && payload.reason !== "review_ended") {
+					const interrupted = payload.reason === "interrupted";
+					task.isErrorInterrupt = interrupted;
+					task.error = interrupted ? "Turn interrupted" : `Turn aborted: ${payload.reason}`;
+				}
 			}
 			if (payload.type === "task_complete" || payload.type === "turn_complete" || payload.type === "turn_aborted" || task != null && index === arr.length - 1 && input.turn_id != null) {
 				task ??= createTask();

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -15607,6 +15607,7 @@ function convertToStandardMessages(messages) {
 }
 const CHILD_SCOPE_RESET = {
 	approval_policy: void 0,
+	ls_is_error_interrupt: void 0,
 	ls_subagent_id: void 0,
 	ls_subagent_type: void 0
 };
@@ -15691,6 +15692,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			...options?.metadata,
 			...task.context,
 			...base,
+			...task.isErrorInterrupt ? { ls_is_error_interrupt: true } : {},
 			approval_policy: isSubagent ? void 0 : approvalPolicy,
 			ls_subagent_id: isSubagent ? sessionMeta?.session_id : void 0,
 			ls_subagent_type: isSubagent ? sessionMeta?.agent_role ?? sessionMeta?.agent_nickname : void 0,
@@ -15818,6 +15820,7 @@ async function convertToRunTree(input, options) {
 			context: void 0,
 			tokenCount: void 0,
 			error: void 0,
+			isErrorInterrupt: false,
 			subagentThreads: [],
 			toolCalls: {}
 		};
@@ -15934,6 +15937,7 @@ async function convertToRunTree(input, options) {
 			}
 			if (payload.type === "turn_aborted") {
 				task ??= createTask();
+				task.isErrorInterrupt = payload.reason === "interrupted";
 				const explicitError = formatError(payload.error);
 				if (explicitError != null) task.error = explicitError;
 				else if (task.error == null && payload.reason !== "review_ended") task.error = payload.reason === "interrupted" ? "Turn interrupted" : `Turn aborted: ${payload.reason}`;

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -351,6 +351,7 @@ function convertToStandardMessages(messages: AggregateMessage<ResponseItem>[]) {
 // parent->child metadata inheritance (serialization drops undefined).
 const CHILD_SCOPE_RESET = {
   approval_policy: undefined,
+  ls_is_error_interrupt: undefined,
   ls_subagent_id: undefined,
   ls_subagent_type: undefined,
 } as const;
@@ -493,6 +494,7 @@ async function postTurn(
         ...options?.metadata,
         ...task.context,
         ...base,
+        ...(task.isErrorInterrupt ? { ls_is_error_interrupt: true } : {}),
 
         approval_policy: isSubagent ? undefined : approvalPolicy,
         ls_subagent_id: isSubagent ? sessionMeta?.session_id : undefined,
@@ -698,6 +700,7 @@ export async function convertToRunTree(
       context: undefined,
       tokenCount: undefined,
       error: undefined,
+      isErrorInterrupt: false,
       subagentThreads: [],
       toolCalls: {},
     };
@@ -875,6 +878,7 @@ export async function convertToRunTree(
 
       if (payload.type === "turn_aborted") {
         task ??= createTask();
+        task.isErrorInterrupt = payload.reason === "interrupted";
         const explicitError = formatError(payload.error);
         if (explicitError != null) {
           task.error = explicitError;

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -878,15 +878,13 @@ export async function convertToRunTree(
 
       if (payload.type === "turn_aborted") {
         task ??= createTask();
-        task.isErrorInterrupt = payload.reason === "interrupted";
         const explicitError = formatError(payload.error);
         if (explicitError != null) {
           task.error = explicitError;
         } else if (task.error == null && payload.reason !== "review_ended") {
-          task.error =
-            payload.reason === "interrupted"
-              ? "Turn interrupted"
-              : `Turn aborted: ${payload.reason}`;
+          const interrupted = payload.reason === "interrupted";
+          task.isErrorInterrupt = interrupted;
+          task.error = interrupted ? "Turn interrupted" : `Turn aborted: ${payload.reason}`;
         }
       }
 

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -1109,6 +1109,7 @@ export type Task = {
   context: { model: string; [key: string]: unknown } | undefined;
   tokenCount: { total_token_usage?: TokenCount; model_context_window?: number } | undefined;
   error: string | undefined;
+  isErrorInterrupt: boolean;
   subagentThreads: string[];
   toolCalls: {
     [callId: string]: {

--- a/plugins/tracing/test/contract.test.ts
+++ b/plugins/tracing/test/contract.test.ts
@@ -261,6 +261,7 @@ describe("turn errors", () => {
     });
 
     expect(run?.error).toBe("Turn interrupted");
+    expect(run?.extra?.metadata?.ls_is_error_interrupt).toBe(true);
   });
 
   it("reports terminal Codex errors with their details", async () => {
@@ -277,6 +278,7 @@ describe("turn errors", () => {
     expect(run?.error).toBe(
       "The model failed while generating a response — Try again later — server_overloaded",
     );
+    expect(run?.extra?.metadata?.ls_is_error_interrupt).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Description
Codex turn interruptions were emitted as ordinary errors, so LangSmith rendered them as failures. Emit `ls_is_error_interrupt` from the authoritative terminal reason and prevent it from leaking to child runs; no configuration or privacy behavior changes.

## Test Plan
- [x] Focused tracing contract tests
- [x] Formatting, TypeScript checks, and committed bundle verification

Made by [Open SWE](https://openswe.vercel.app/agents/a5d87be4-5a69-ea51-0ad1-efd7704c06a4)