### PR TITLE
bump tracing to 0.0.7

### DIFF
--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -15210,7 +15210,7 @@ const LS_AGENT_PURPOSE = "coding";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.6";
+const LS_INTEGRATION_VERSION = "0.0.7";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }


### PR DESCRIPTION
## Description

Release `tracing` 0.0.7. Codex caches installed plugins by version, so this bump invalidates the cache and ships the interrupted-run-status fix (#31) without users clearing it by hand.

Included since 0.0.6:
- #31 — classify Codex turn interruptions via `ls_is_error_interrupt`, so interrupted turns render as interrupts rather than red errors.

## Test Plan

- [x] `pnpm vitest run` — 33/33 pass
- [x] `pnpm run lint` — oxfmt, tsc, and committed-bundle checks clean
- [x] Version baked into `dist/index.mjs` as `LS_INTEGRATION_VERSION = "0.0.7"`

Users pick this up with `codex plugin marketplace upgrade`.
