### PR TITLE
feat: add sticky per-thread trace controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Subagent threads are resolved and uploaded as nested child runs under the parent
 
 Interrupted turns (where the user cancels mid-response) are still uploaded upon session completion.
 
+### Per-thread tracing controls
+
+Use the exact lowercase commands `/trace on`, `/trace off`, and `/trace status`. Commands are blocked before they become transcript turns and therefore are never traced. `/trace off` keeps topology, timing, usage, thread/turn IDs, and safe integration metadata while omitting messages, tool payloads, errors, workspace details, inherited baggage metadata, and replica updates. The selected mode is snapshotted when a prompt with `turn_id` is submitted, so later commands do not change earlier turns. Compatibility prompts without `turn_id` enqueue only a metadata-only FIFO marker; they never persist prompt content or identity and can never enable full-content tracing. Subagents inherit the mode active when the parent launched them.
+
+The preference is stored in `~/.codex/langsmith-state.json`. If it is malformed, tracing fails closed to metadata-only; an explicit `/trace on` or `/trace off` quarantines the corrupt file and creates valid state. A malformed project config or an invalid present environment setting disables tracing. `TRACE_TO_LANGSMITH=false` remains the master switch: commands may update the saved preference, but status reports that tracing is disabled by configuration.
+
 ## Secret redaction
 
 By default, the plugin strips common secrets — provider API keys, JWTs, PEM blocks, and structural `NAME=value`, `Authorization`, and URL-credential shapes — from run inputs, outputs, and metadata **before they are uploaded** to LangSmith.

--- a/plugins/tracing/.codex-plugin/plugin.json
+++ b/plugins/tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Trace OpenAI Codex rollout transcripts to LangSmith.",
   "author": {
     "name": "LangChain",

--- a/plugins/tracing/dist/index.d.mts
+++ b/plugins/tracing/dist/index.d.mts
@@ -1,0 +1,16 @@
+//#region src/index.d.ts
+type CommonInput = {
+  session_id?: string;
+  thread_id?: string;
+  transcript_path: string | null;
+  turn_id?: string;
+  prompt_id?: string;
+};
+type PromptInput = CommonInput & {
+  hook_event_name: "UserPromptSubmit";
+  prompt: string;
+};
+declare function handleUserPromptSubmit(input: PromptInput): Promise<boolean>;
+declare function runHook(): Promise<void>;
+//#endregion
+export { handleUserPromptSubmit, runHook };

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -1765,7 +1765,7 @@ const safeJSON = (text) => {
 };
 //#endregion
 //#region ../../node_modules/.pnpm/langsmith@0.8.11_@opentelemetry+api@1.9.1_@opentelemetry+exporter-trace-otlp-proto@0.21_fc9c488f4e5a73a2aaf25bc15573e6b5/node_modules/langsmith/dist/_openapi_client/internal/utils/sleep.js
-const sleep$1 = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep$2 = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 //#endregion
 //#region ../../node_modules/.pnpm/langsmith@0.8.11_@opentelemetry+api@1.9.1_@opentelemetry+exporter-trace-otlp-proto@0.21_fc9c488f4e5a73a2aaf25bc15573e6b5/node_modules/langsmith/dist/_openapi_client/version.js
 const VERSION = "0.0.1";
@@ -4225,7 +4225,7 @@ var Langsmith = class {
 			const maxRetries = options.maxRetries ?? this.maxRetries;
 			timeoutMillis = this.calculateDefaultRetryTimeoutMillis(retriesRemaining, maxRetries);
 		}
-		await sleep$1(timeoutMillis);
+		await sleep$2(timeoutMillis);
 		return this.makeRequest(options, retriesRemaining - 1, requestLogID);
 	}
 	calculateDefaultRetryTimeoutMillis(retriesRemaining, maxRetries) {
@@ -5362,7 +5362,7 @@ const _getFetchImplementation = (debug) => {
 const LOCK_POLL_INTERVAL_MS = 10;
 const LOCK_STALE_AFTER_MS = 1e4;
 const LOCK_METADATA_FILE = "created_at";
-function sleep(ms) {
+function sleep$1(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isEEXIST(err) {
@@ -5414,7 +5414,7 @@ async function acquireOAuthRefreshLock(configPath, deadline) {
 			if (!isEEXIST(err)) throw err;
 			if (!await removeStaleLock(lockDir)) {
 				if (Date.now() >= deadline) throw new Error("timed out acquiring OAuth refresh lock");
-				await sleep(Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+				await sleep$1(Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
 			}
 			continue;
 		}
@@ -15776,16 +15776,24 @@ const ReplicaSchema = preprocess((value) => {
 	if (value == null || typeof value !== "object" || Array.isArray(value)) return value;
 	const replica = value;
 	return {
-		api_url: replica.api_url ?? replica.apiUrl,
-		api_key: replica.api_key ?? replica.apiKey,
-		project: replica.project ?? replica.projectName,
-		updates: replica.updates
+		apiUrl: replica.apiUrl ?? replica.api_url,
+		apiKey: replica.apiKey ?? replica.api_key,
+		workspaceId: replica.workspaceId ?? replica.workspace_id,
+		projectName: replica.projectName ?? replica.project_name ?? replica.project,
+		primary: replica.primary,
+		updates: replica.updates,
+		fromEnv: replica.fromEnv ?? replica.from_env,
+		reroot: replica.reroot
 	};
 }, object({
-	api_url: string().optional(),
-	api_key: string().optional(),
-	project: string().optional(),
-	updates: record(string(), unknown()).optional()
+	apiUrl: string().optional(),
+	apiKey: string().optional(),
+	workspaceId: string().optional(),
+	projectName: string().optional(),
+	primary: boolean().optional(),
+	updates: record(string(), unknown()).optional(),
+	fromEnv: boolean().optional(),
+	reroot: boolean().optional()
 }));
 const ConfigSchema = object({
 	enabled: boolean(),
@@ -15835,21 +15843,36 @@ const stripUndefined$1 = (value) => {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 };
 async function readConfigFile(file) {
+	let data;
 	try {
-		const data = await nodeFsPromises.readFile(file, "utf-8");
-		return PartialConfigSchema.parse(JSON.parse(data));
+		data = await nodeFsPromises.readFile(file, "utf-8");
+	} catch (error) {
+		return { invalid: !(error != null && typeof error === "object" && "code" in error && error.code === "ENOENT") };
+	}
+	try {
+		return {
+			config: PartialConfigSchema.parse(JSON.parse(data)),
+			invalid: false
+		};
 	} catch {
-		return;
+		return { invalid: true };
 	}
 }
 function getVar(suffix, env) {
 	return env[`LANGSMITH_CODEX_${suffix}`] ?? env[`LANGSMITH_${suffix}`];
 }
 const readConfigEnv = (env) => {
-	const enabled = parseBoolean(env.TRACE_TO_LANGSMITH);
+	const present = [
+		"TRACE_TO_LANGSMITH",
+		"METADATA",
+		"RUNS_ENDPOINTS",
+		"PARENT_HEADERS",
+		"REDACT",
+		"REDACT_EXTRA"
+	].some((name) => name === "TRACE_TO_LANGSMITH" ? env[name] != null : getVar(name, env) != null);
 	try {
-		return stripUndefined$1(PartialConfigSchema.parse({
-			enabled,
+		const config = stripUndefined$1(PartialConfigSchema.parse({
+			enabled: parseBoolean(env.TRACE_TO_LANGSMITH),
 			api_key: getVar("API_KEY", env),
 			api_url: getVar("ENDPOINT", env),
 			project: getVar("PROJECT", env),
@@ -15859,8 +15882,20 @@ const readConfigEnv = (env) => {
 			redact: parseBoolean(getVar("REDACT", env)),
 			redact_extra_rules: parseJson(getVar("REDACT_EXTRA", env))
 		}));
+		return {
+			config,
+			invalid: env.TRACE_TO_LANGSMITH != null && config.enabled == null || [
+				"METADATA",
+				"RUNS_ENDPOINTS",
+				"PARENT_HEADERS",
+				"REDACT_EXTRA"
+			].some((name) => getVar(name, env) != null && parseJson(getVar(name, env)) == null) || getVar("REDACT", env) != null && config.redact == null
+		};
 	} catch {
-		return {};
+		return {
+			config: {},
+			invalid: present
+		};
 	}
 };
 const getHomeDir = () => process.env.HOME ?? os.homedir();
@@ -15870,14 +15905,267 @@ async function getConfig(options) {
 	const env = options?.env ?? process.env;
 	const envConfig = readConfigEnv(env);
 	const [globalConfig, localConfig] = await Promise.all([readConfigFile(nodePath.join(home, ".codex", "langsmith.json")), readConfigFile(nodePath.join(cwd, ".codex", "langsmith.json"))]);
+	const invalid = envConfig.invalid || globalConfig.invalid || localConfig.invalid;
 	return ConfigSchema.parse({
 		project: "codex",
 		enabled: false,
 		redact: true,
-		...globalConfig,
-		...localConfig,
-		...envConfig
+		...globalConfig.config,
+		...localConfig.config,
+		...envConfig.config,
+		...invalid ? { enabled: false } : {}
 	});
+}
+//#endregion
+//#region src/state.ts
+const RETENTION_MS = 6048e5;
+const emptyState = () => ({
+	version: 2,
+	threads: {},
+	turns: {},
+	roots: {},
+	pending: {}
+});
+const sleep = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+function statePath(home = process.env.HOME ?? os.homedir()) {
+	return nodePath.join(home, ".codex", "langsmith-state.json");
+}
+function parseState(data) {
+	try {
+		const value = JSON.parse(data);
+		if (value == null || typeof value !== "object" || Array.isArray(value)) return void 0;
+		const pending = value.pending ?? {};
+		for (const entry of [
+			value.threads,
+			value.turns,
+			value.roots,
+			pending
+		]) if (entry == null || typeof entry !== "object" || Array.isArray(entry)) return void 0;
+		if (value.version !== 2) return void 0;
+		const state = {
+			...value,
+			pending
+		};
+		if (Object.values(state.threads).some((entry) => entry == null || typeof entry !== "object" || Array.isArray(entry) || typeof entry.updatedAt !== "number" || entry.tracing != null && entry.tracing !== "metadata")) return void 0;
+		if (Object.values(state.turns).some((entry) => entry == null || typeof entry !== "object" || ![
+			"full",
+			"metadata",
+			"skip"
+		].includes(entry.mode) || typeof entry.root !== "string" || typeof entry.updatedAt !== "number")) return void 0;
+		if (Object.values(state.roots).some((entry) => entry == null || typeof entry !== "object" || typeof entry.root !== "string" || typeof entry.updatedAt !== "number")) return void 0;
+		if (Object.values(state.pending).some((queue) => !Array.isArray(queue) || queue.some((entry) => entry == null || typeof entry !== "object" || typeof entry.createdAt !== "number"))) return void 0;
+		return state;
+	} catch {
+		return;
+	}
+}
+function readTracingState(home) {
+	try {
+		const parsed = parseState(nodeFs.readFileSync(statePath(home), "utf8"));
+		return parsed == null ? {
+			state: emptyState(),
+			malformed: true
+		} : {
+			state: parsed,
+			malformed: false
+		};
+	} catch (error) {
+		return error.code === "ENOENT" ? {
+			state: emptyState(),
+			malformed: false
+		} : {
+			state: emptyState(),
+			malformed: true
+		};
+	}
+}
+function processAlive(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return error.code === "EPERM";
+	}
+}
+function staleLock(lock) {
+	try {
+		const owner = JSON.parse(nodeFs.readFileSync(nodePath.join(lock, "owner.json"), "utf8"));
+		return typeof owner.pid !== "number" || typeof owner.created !== "number" || Date.now() - owner.created > 3e4 || !processAlive(owner.pid);
+	} catch {
+		try {
+			return Date.now() - nodeFs.statSync(lock).mtimeMs > 3e4;
+		} catch {
+			return true;
+		}
+	}
+}
+function rootForThread(state, threadId) {
+	let current = threadId;
+	const seen = /* @__PURE__ */ new Set();
+	while (state.roots[current] != null && !seen.has(current)) {
+		seen.add(current);
+		current = state.roots[current].root;
+	}
+	return current;
+}
+function collectRoot(state, root) {
+	delete state.threads[root];
+	delete state.pending[root];
+	for (const [turnId, entry] of Object.entries(state.turns)) if (entry.root === root) delete state.turns[turnId];
+	for (const [threadId, entry] of Object.entries(state.roots)) if (threadId === root || rootForThread(state, threadId) === root) delete state.roots[threadId];
+}
+function gc(state, now) {
+	const cutoff = now - RETENTION_MS;
+	const activeRoots = /* @__PURE__ */ new Set();
+	for (const [root, entry] of Object.entries(state.threads)) if (entry.updatedAt >= cutoff) activeRoots.add(root);
+	for (const entry of Object.values(state.turns)) if (entry.updatedAt >= cutoff) activeRoots.add(entry.root);
+	for (const [thread, entry] of Object.entries(state.roots)) if (entry.updatedAt >= cutoff) activeRoots.add(rootForThread(state, thread));
+	for (const [root, queue] of Object.entries(state.pending)) {
+		state.pending[root] = queue.filter((entry) => entry.createdAt >= cutoff);
+		if (state.pending[root].length > 0) activeRoots.add(root);
+		else delete state.pending[root];
+	}
+	const roots = /* @__PURE__ */ new Set([
+		...Object.keys(state.threads),
+		...Object.values(state.turns).map((entry) => entry.root),
+		...Object.keys(state.pending),
+		...Object.keys(state.roots).map((thread) => rootForThread(state, thread))
+	]);
+	for (const root of roots) if (!activeRoots.has(root)) collectRoot(state, root);
+}
+function withLock(home, update, recoverMalformed = false) {
+	const file = statePath(home);
+	const dir = nodePath.dirname(file);
+	const lock = nodePath.join(dir, "langsmith-state.lock");
+	nodeFs.mkdirSync(dir, {
+		recursive: true,
+		mode: 448
+	});
+	for (let attempt = 0;; attempt += 1) try {
+		nodeFs.mkdirSync(lock, { mode: 448 });
+		nodeFs.writeFileSync(nodePath.join(lock, "owner.json"), JSON.stringify({
+			pid: process.pid,
+			created: Date.now()
+		}));
+		break;
+	} catch (error) {
+		if (error.code !== "EEXIST") throw error;
+		if (staleLock(lock)) {
+			nodeFs.rmSync(lock, {
+				recursive: true,
+				force: true
+			});
+			continue;
+		}
+		if (attempt >= 200) throw new Error("Timed out waiting for LangSmith tracing state lock");
+		sleep();
+	}
+	try {
+		const loaded = readTracingState(home);
+		if (loaded.malformed && !recoverMalformed) throw new Error("Malformed LangSmith tracing state");
+		if (loaded.malformed && nodeFs.existsSync(file)) nodeFs.renameSync(file, `${file}.corrupt-${Date.now()}-${process.pid}`);
+		const state = loaded.malformed ? emptyState() : loaded.state;
+		const now = Date.now();
+		gc(state, now);
+		const result = update(state, now);
+		const temp = nodePath.join(dir, `.langsmith-state-${process.pid}-${Date.now()}.tmp`);
+		nodeFs.writeFileSync(temp, JSON.stringify(state), { mode: 384 });
+		nodeFs.renameSync(temp, file);
+		return result;
+	} finally {
+		nodeFs.rmSync(lock, {
+			recursive: true,
+			force: true
+		});
+	}
+}
+function modeInState(state, threadId) {
+	return state.threads[rootForThread(state, threadId)]?.tracing === "metadata" ? "metadata" : "full";
+}
+function getThreadMode(threadId, home) {
+	const loaded = readTracingState(home);
+	return loaded.malformed ? "metadata" : modeInState(loaded.state, threadId);
+}
+function setThreadMode(threadId, mode, home) {
+	withLock(home, (state, now) => {
+		const root = rootForThread(state, threadId);
+		state.threads[root] = {
+			...mode === "metadata" ? { tracing: "metadata" } : {},
+			updatedAt: now
+		};
+	}, true);
+}
+function linkThreadRoot(threadId, rootId, home) {
+	withLock(home, (state, now) => {
+		const oldMode = modeInState(state, threadId);
+		const root = rootForThread(state, rootId);
+		state.roots[threadId] = {
+			root,
+			updatedAt: now
+		};
+		if (oldMode === "metadata") state.threads[root] = {
+			tracing: "metadata",
+			updatedAt: now
+		};
+	});
+}
+function enqueuePendingMode(threadId, home) {
+	withLock(home, (state, now) => {
+		const root = rootForThread(state, threadId);
+		(state.pending[root] ??= []).push({ createdAt: now });
+	});
+}
+function snapshotCurrentTurnMode(threadId, turnId, home) {
+	return withLock(home, (state, now) => {
+		const existing = state.turns[turnId];
+		if (existing != null) return existing.mode === "full" ? "full" : "metadata";
+		const root = rootForThread(state, threadId);
+		const mode = modeInState(state, root);
+		state.turns[turnId] = {
+			mode,
+			root,
+			updatedAt: now
+		};
+		return mode;
+	});
+}
+function snapshotTurnMode(threadId, turnId, inheritedMode, home) {
+	return withLock(home, (state, now) => {
+		const existing = state.turns[turnId];
+		if (existing != null) return existing.mode === "full" ? "full" : "metadata";
+		const root = rootForThread(state, threadId);
+		const queue = state.pending[root];
+		if (queue != null) {
+			queue.shift();
+			if (queue.length === 0) delete state.pending[root];
+		}
+		const mode = inheritedMode ?? "metadata";
+		state.turns[turnId] = {
+			mode,
+			root,
+			updatedAt: now
+		};
+		return mode;
+	});
+}
+function markTurnHandled(turnId, home) {
+	withLock(home, (state, now) => {
+		const existing = state.turns[turnId];
+		state.turns[turnId] = {
+			mode: "skip",
+			root: existing?.root ?? "unknown",
+			updatedAt: now
+		};
+	});
+}
+function isTurnHandled(turnId, home) {
+	const loaded = readTracingState(home);
+	return !loaded.malformed && loaded.state.turns[turnId]?.mode === "skip";
+}
+function getTurnMode(turnId, _threadId, home) {
+	const loaded = readTracingState(home);
+	if (loaded.malformed || turnId == null) return "metadata";
+	return loaded.state.turns[turnId]?.mode === "full" ? "full" : "metadata";
 }
 //#endregion
 //#region src/utils/findLast.ts
@@ -15910,7 +16198,7 @@ const LS_AGENT_PURPOSE = "coding";
 const LS_INTEGRATION = "openai-codex";
 const LS_AGENT_RUNTIME = "Codex";
 const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
-const LS_INTEGRATION_VERSION = "0.0.7";
+const LS_INTEGRATION_VERSION = "0.0.8";
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== void 0));
 }
@@ -16377,18 +16665,47 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		git,
 		sandboxType
 	});
+	const mode = options?.turnMode ?? getTurnMode(task.turnId?.id, conversationThreadId ?? sessionMeta?.session_id ?? "");
+	const status = task.error == null ? "completed" : "error";
+	const metadataBase = {
+		...Object.fromEntries(Object.entries(base).filter(([key]) => key === "thread_id" || key === "turn_id" || key === "turn_number" || key.startsWith("ls_agent_") || key === "ls_integration" || key === "ls_integration_version" || key === "ls_trace_schema_version")),
+		status,
+		ls_tracing_mode: "metadata"
+	};
+	const safeReplicas = mode === "metadata" ? options?.replicas?.map((replica) => {
+		if (Array.isArray(replica)) return replica;
+		const { updates: _, ...safe } = replica;
+		return safe;
+	}) : options?.replicas;
+	const topologyParent = mode === "metadata" && options?.parentRunTree != null ? new RunTree({
+		name: "distributed-parent",
+		id: options.parentRunTree.id,
+		trace_id: options.parentRunTree.trace_id,
+		dotted_order: options.parentRunTree.dotted_order,
+		client: options.client,
+		project_name: options.projectName,
+		inputs: {},
+		outputs: {},
+		extra: { metadata: {} },
+		replicas: safeReplicas
+	}) : options?.parentRunTree;
 	const parentConfig = {
 		name: "openai.codex",
 		client: options?.client,
 		project_name: options?.projectName,
 		run_type: "chain",
-		replicas: options?.replicas,
-		inputs: { messages: user != null ? [user.message] : [] },
-		outputs: { messages: agent.map((i) => i.message) },
-		error: task.error,
+		replicas: safeReplicas,
+		inputs: mode === "metadata" ? {} : { messages: user != null ? [user.message] : [] },
+		outputs: mode === "metadata" ? {} : { messages: agent.map((i) => i.message) },
+		error: mode === "metadata" ? void 0 : task.error,
 		start_time: parentStartTime,
 		end_time: parentEndTime,
-		extra: { metadata: {
+		extra: { metadata: mode === "metadata" ? {
+			...metadataBase,
+			ls_subagent_id: isSubagent ? sessionMeta?.session_id : void 0,
+			ls_subagent_type: isSubagent ? sessionMeta?.agent_role ?? sessionMeta?.agent_nickname : void 0,
+			ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage)
+		} : {
 			...options?.metadata,
 			...task.context,
 			...base,
@@ -16401,7 +16718,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage)
 		} }
 	};
-	const parent = options?.parentRunTree?.createChild(parentConfig) ?? new RunTree(parentConfig);
+	const parent = topologyParent?.createChild(parentConfig) ?? new RunTree(parentConfig);
 	PROMISE_QUEUE.push(parent.postRun());
 	const fullMessages = mergeMessages([...getSystemMessage(sessionMeta, task), ...messages]);
 	const outputs = fullMessages.reduce((acc, item, idx) => {
@@ -16435,7 +16752,8 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		}, {
 			...options,
 			parentRunTree: parent,
-			debugNow
+			debugNow,
+			turnMode: mode
 		});
 	}
 	for (const output of outputs) {
@@ -16451,9 +16769,14 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 			run_type: "llm",
 			start_time: outputStartTime,
 			end_time: outputEndTime,
-			inputs: { messages: inputMessages.map((i) => i.message) },
-			outputs: { messages: aiMessage.map((i) => i.message) },
-			extra: { metadata: {
+			inputs: mode === "metadata" ? {} : { messages: inputMessages.map((i) => i.message) },
+			outputs: mode === "metadata" ? {} : { messages: aiMessage.map((i) => i.message) },
+			extra: { metadata: mode === "metadata" ? {
+				...metadataBase,
+				...CHILD_SCOPE_RESET,
+				ls_model_name: task.context?.model,
+				usage_metadata: getUsageMetadata(tokenCounts)
+			} : {
 				...options?.metadata,
 				...base,
 				...CHILD_SCOPE_RESET,
@@ -16485,13 +16808,19 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 				run_type: "tool",
 				start_time: min,
 				end_time: max,
-				inputs: { input: msgToolCall.args },
-				outputs: {
+				inputs: mode === "metadata" ? {} : { input: msgToolCall.args },
+				outputs: mode === "metadata" ? {} : {
 					...toolCall.outputs,
 					messages: [toolMessage.message]
 				},
-				error: toolCall.error,
-				extra: { metadata: {
+				error: mode === "metadata" ? void 0 : toolCall.error,
+				extra: { metadata: mode === "metadata" ? {
+					...metadataBase,
+					...CHILD_SCOPE_RESET,
+					ls_model_name: task.context?.model,
+					ls_tool_name: nativeToolName,
+					usage_metadata: getUsageMetadata(toolMessage.tokenCount)
+				} : {
 					...options?.metadata,
 					...base,
 					...CHILD_SCOPE_RESET,
@@ -16508,6 +16837,7 @@ async function postTurn(task, sessionMeta, { rolloutFile, options }) {
 		for (const subagentThread of subagentThreads ?? []) await postSubagentThread(subagentThread);
 	}
 	for (const subagentThread of task.subagentThreads) await postSubagentThread(subagentThread);
+	await Promise.all(PROMISE_QUEUE.splice(0));
 }
 async function convertToRunTree(input, options) {
 	let sessionMeta;
@@ -16541,6 +16871,10 @@ async function convertToRunTree(input, options) {
 			const source = payload.source;
 			const threadSpawn = source != null && typeof source === "object" && "subagent" in source ? source.subagent?.thread_spawn : void 0;
 			const isSubagent = threadSpawn != null || payload.thread_source === "subagent" && typeof payload.parent_thread_id === "string";
+			const parentThreadId = threadSpawn?.parent_thread_id ?? payload.parent_thread_id ?? void 0;
+			if (isSubagent && parentThreadId != null) try {
+				linkThreadRoot(payload.id, parentThreadId);
+			} catch {}
 			sessionMeta = {
 				session_id: payload.id,
 				model_provider: payload.model_provider ?? void 0,
@@ -16549,7 +16883,7 @@ async function convertToRunTree(input, options) {
 				cwd: payload.cwd,
 				git: payload.git,
 				is_subagent: isSubagent,
-				parent_thread_id: threadSpawn?.parent_thread_id ?? payload.parent_thread_id ?? void 0,
+				parent_thread_id: parentThreadId,
 				agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? void 0,
 				agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? void 0
 			};
@@ -16584,6 +16918,9 @@ async function convertToRunTree(input, options) {
 					timestamp: eventTime
 				};
 				task.turnNumber = turnNumber;
+				if (sessionMeta != null) try {
+					snapshotTurnMode(sessionMeta.parent_thread_id ?? sessionMeta.session_id, payload.turn_id, options?.turnMode);
+				} catch {}
 			}
 			if (typeof payload.call_id === "string") {
 				task ??= createTask();
@@ -16657,14 +16994,22 @@ async function convertToRunTree(input, options) {
 					turnNumber += 1;
 					task.turnNumber = turnNumber;
 				}
-				if (completedTurnId == null || !uploadedTurnIds.has(completedTurnId)) {
+				if (completedTurnId == null || !uploadedTurnIds.has(completedTurnId) && !isTurnHandled(completedTurnId)) {
+					const threadId = sessionMeta?.parent_thread_id ?? sessionMeta?.session_id ?? "";
+					const mode = options?.turnMode ?? (options?.failClosedMissingSnapshot ? getTurnMode(completedTurnId, threadId) : getThreadMode(threadId));
 					await postTurn(task, sessionMeta, {
 						rolloutFile: input.transcript_path,
-						options
+						options: {
+							...options,
+							turnMode: mode
+						}
 					});
 					if (completedTurnId != null) {
 						uploadedTurnIds.add(completedTurnId);
-						await markTurnUploaded(input.transcript_path, completedTurnId);
+						if (mode === "metadata") try {
+							markTurnHandled(completedTurnId);
+						} catch {}
+						else await markTurnUploaded(input.transcript_path, completedTurnId);
 					}
 				}
 				task = void 0;
@@ -16693,28 +17038,82 @@ function readStdin() {
 }
 //#endregion
 //#region src/index.ts
-async function runHook() {
-	const content = await readStdin();
+function transcript(input) {
+	if (input.transcript_path == null) return [];
+	try {
+		return nodeFs.readFileSync(input.transcript_path, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+	} catch {
+		return [];
+	}
+}
+function inputThread(input) {
+	return input.thread_id ?? input.session_id ?? "unknown";
+}
+function resolveRoot(input) {
+	const thread = inputThread(input);
+	const payload = transcript(input).find((line) => line.type === "session_meta")?.payload;
+	const parent = (payload?.source)?.subagent?.thread_spawn?.parent_thread_id ?? (payload?.thread_source === "subagent" ? payload.parent_thread_id : void 0);
+	if (typeof parent === "string") {
+		try {
+			linkThreadRoot(thread, parent);
+		} catch {}
+		return parent;
+	}
+	return thread;
+}
+function commandOutput(reason) {
+	process.stdout.write(JSON.stringify({
+		decision: "block",
+		reason
+	}));
+}
+async function handleUserPromptSubmit(input) {
+	const root = resolveRoot(input);
+	const command = /^\/trace (on|off|status)$/.exec(input.prompt)?.[1];
 	const config = await getConfig();
-	if (!config.enabled) return;
+	if (command != null) {
+		if (command === "on") setThreadMode(root, "full");
+		if (command === "off") setThreadMode(root, "metadata");
+		if (!config.enabled) commandOutput("LangSmith tracing is disabled by configuration for this thread.");
+		else commandOutput(getThreadMode(root) === "full" ? "LangSmith tracing is on for this thread." : "LangSmith tracing is off for this thread (metadata only).");
+		return true;
+	}
+	try {
+		if (input.turn_id != null) snapshotCurrentTurnMode(root, input.turn_id);
+		else enqueuePendingMode(root);
+	} catch {}
+	return false;
+}
+async function handleStop(content) {
+	const config = await getConfig();
+	if (!config.enabled || content.transcript_path == null) return;
 	const anonymizer = config.redact ? createSecretAnonymizer(config.redact_extra_rules ? { extraRules: config.redact_extra_rules } : void 0) : void 0;
 	const client = new Client({
 		apiKey: config.api_key,
 		apiUrl: config.api_url,
 		anonymizer
 	});
-	const parentRunTree = config.parent_headers ? RunTree.fromHeaders(config.parent_headers, {
+	const parentRunTree = config.parent_headers?.["langsmith-trace"] ? RunTree.fromHeaders(config.parent_headers, {
 		client,
 		project_name: config.project
 	}) : void 0;
-	await convertToRunTree(content, {
+	await convertToRunTree({
+		transcript_path: content.transcript_path,
+		turn_id: content.turn_id ?? null
+	}, {
 		client,
 		projectName: config.project,
 		metadata: config.metadata,
 		replicas: config.replicas,
-		parentRunTree
+		parentRunTree,
+		failClosedMissingSnapshot: true
 	});
+}
+async function runHook() {
+	const content = await readStdin();
+	if (content.hook_event_name === "UserPromptSubmit") await handleUserPromptSubmit(content);
+	else await handleStop(content);
 }
 runHook();
 //#endregion
-export { runHook };
+export { handleUserPromptSubmit, runHook };

--- a/plugins/tracing/hooks/hooks.json
+++ b/plugins/tracing/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/dist/index.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/tracing/src/config.ts
+++ b/plugins/tracing/src/config.ts
@@ -6,23 +6,29 @@ import { z } from "zod";
 
 const ReplicaSchema = z.preprocess(
   (value) => {
-    if (value == null || typeof value !== "object" || Array.isArray(value)) {
-      return value;
-    }
+    if (value == null || typeof value !== "object" || Array.isArray(value)) return value;
 
     const replica = value as Record<string, unknown>;
     return {
-      api_url: replica.api_url ?? replica.apiUrl,
-      api_key: replica.api_key ?? replica.apiKey,
-      project: replica.project ?? replica.projectName,
+      apiUrl: replica.apiUrl ?? replica.api_url,
+      apiKey: replica.apiKey ?? replica.api_key,
+      workspaceId: replica.workspaceId ?? replica.workspace_id,
+      projectName: replica.projectName ?? replica.project_name ?? replica.project,
+      primary: replica.primary,
       updates: replica.updates,
+      fromEnv: replica.fromEnv ?? replica.from_env,
+      reroot: replica.reroot,
     };
   },
   z.object({
-    api_url: z.string().optional(),
-    api_key: z.string().optional(),
-    project: z.string().optional(),
+    apiUrl: z.string().optional(),
+    apiKey: z.string().optional(),
+    workspaceId: z.string().optional(),
+    projectName: z.string().optional(),
+    primary: z.boolean().optional(),
     updates: z.record(z.string(), z.unknown()).optional(),
+    fromEnv: z.boolean().optional(),
+    reroot: z.boolean().optional(),
   }),
 );
 
@@ -92,12 +98,26 @@ const stripUndefined = <T extends Record<string, unknown>>(value: T): Partial<T>
   ) as Partial<T>;
 };
 
-async function readConfigFile(file: string): Promise<Partial<Config> | undefined> {
+async function readConfigFile(
+  file: string,
+): Promise<{ config?: Partial<Config>; invalid: boolean }> {
+  let data: string;
   try {
-    const data = await fs.readFile(file, "utf-8");
-    return PartialConfigSchema.parse(JSON.parse(data));
+    data = await fs.readFile(file, "utf-8");
+  } catch (error) {
+    return {
+      invalid: !(
+        error != null &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ),
+    };
+  }
+  try {
+    return { config: PartialConfigSchema.parse(JSON.parse(data)), invalid: false };
   } catch {
-    return undefined;
+    return { invalid: true };
   }
 }
 
@@ -105,13 +125,24 @@ function getVar(suffix: string, env: Record<string, string | undefined>): string
   return env[`LANGSMITH_CODEX_${suffix}`] ?? env[`LANGSMITH_${suffix}`];
 }
 
-const readConfigEnv = (env: Record<string, string | undefined>): Partial<Config> => {
-  const enabled = parseBoolean(env.TRACE_TO_LANGSMITH);
-
+const readConfigEnv = (
+  env: Record<string, string | undefined>,
+): { config: Partial<Config>; invalid: boolean } => {
+  const names = [
+    "TRACE_TO_LANGSMITH",
+    "METADATA",
+    "RUNS_ENDPOINTS",
+    "PARENT_HEADERS",
+    "REDACT",
+    "REDACT_EXTRA",
+  ];
+  const present = names.some((name) =>
+    name === "TRACE_TO_LANGSMITH" ? env[name] != null : getVar(name, env) != null,
+  );
   try {
-    return stripUndefined(
+    const config = stripUndefined(
       PartialConfigSchema.parse({
-        enabled,
+        enabled: parseBoolean(env.TRACE_TO_LANGSMITH),
         api_key: getVar("API_KEY", env),
         api_url: getVar("ENDPOINT", env),
         project: getVar("PROJECT", env),
@@ -122,12 +153,15 @@ const readConfigEnv = (env: Record<string, string | undefined>): Partial<Config>
         redact_extra_rules: parseJson(getVar("REDACT_EXTRA", env)),
       }),
     );
+    const invalid =
+      (env.TRACE_TO_LANGSMITH != null && config.enabled == null) ||
+      ["METADATA", "RUNS_ENDPOINTS", "PARENT_HEADERS", "REDACT_EXTRA"].some(
+        (name) => getVar(name, env) != null && parseJson(getVar(name, env)) == null,
+      ) ||
+      (getVar("REDACT", env) != null && config.redact == null);
+    return { config, invalid };
   } catch {
-    // A malformed env value (e.g. METADATA / RUNS_ENDPOINTS / REDACT_EXTRA that
-    // parses as JSON but doesn't match the schema) would otherwise throw and
-    // crash the hook. Fall back to file config + defaults, mirroring
-    // readConfigFile().
-    return {};
+    return { config: {}, invalid: present };
   }
 };
 
@@ -147,13 +181,15 @@ export async function getConfig(options?: {
     readConfigFile(path.join(home, ".codex", "langsmith.json")),
     readConfigFile(path.join(cwd, ".codex", "langsmith.json")),
   ]);
+  const invalid = envConfig.invalid || globalConfig.invalid || localConfig.invalid;
 
   return ConfigSchema.parse({
     project: "codex",
     enabled: false,
     redact: true,
-    ...globalConfig,
-    ...localConfig,
-    ...envConfig,
+    ...globalConfig.config,
+    ...localConfig.config,
+    ...envConfig.config,
+    ...(invalid ? { enabled: false } : {}),
   });
 }

--- a/plugins/tracing/src/index.ts
+++ b/plugins/tracing/src/index.ts
@@ -1,51 +1,124 @@
+import * as fs from "node:fs";
 import { Client, RunTree } from "langsmith";
 import { createSecretAnonymizer } from "langsmith/anonymizer";
 import { getConfig } from "./config.js";
+import {
+  enqueuePendingMode,
+  getThreadMode,
+  linkThreadRoot,
+  setThreadMode,
+  snapshotCurrentTurnMode,
+} from "./state.js";
 import { convertToRunTree } from "./trace.js";
 import { readStdin } from "./utils/stdin.js";
 
-export async function runHook() {
-  const content = await readStdin<{
-    session_id: string;
-    turn_id: string;
-    transcript_path: string;
-    hook_event_name: "Stop";
-  }>();
+type CommonInput = {
+  session_id?: string;
+  thread_id?: string;
+  transcript_path: string | null;
+  turn_id?: string;
+  prompt_id?: string;
+};
+type StopInput = CommonInput & { hook_event_name: "Stop" };
+type PromptInput = CommonInput & { hook_event_name: "UserPromptSubmit"; prompt: string };
+type HookInput = StopInput | PromptInput;
 
+function transcript(input: CommonInput): Record<string, unknown>[] {
+  if (input.transcript_path == null) return [];
+  try {
+    return fs
+      .readFileSync(input.transcript_path, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+  } catch {
+    return [];
+  }
+}
+
+function inputThread(input: CommonInput): string {
+  return input.thread_id ?? input.session_id ?? "unknown";
+}
+
+function resolveRoot(input: CommonInput): string {
+  const thread = inputThread(input);
+  const first = transcript(input).find((line) => line.type === "session_meta");
+  const payload = first?.payload as Record<string, unknown> | undefined;
+  const source = payload?.source as
+    | { subagent?: { thread_spawn?: { parent_thread_id?: unknown } } }
+    | undefined;
+  const parent =
+    source?.subagent?.thread_spawn?.parent_thread_id ??
+    (payload?.thread_source === "subagent" ? payload.parent_thread_id : undefined);
+  if (typeof parent === "string") {
+    try {
+      linkThreadRoot(thread, parent);
+    } catch {}
+    return parent;
+  }
+  return thread;
+}
+
+function commandOutput(reason: string): void {
+  process.stdout.write(JSON.stringify({ decision: "block", reason }));
+}
+
+export async function handleUserPromptSubmit(input: PromptInput): Promise<boolean> {
+  const root = resolveRoot(input);
+  const command = /^\/trace (on|off|status)$/.exec(input.prompt)?.[1];
   const config = await getConfig();
+  if (command != null) {
+    if (command === "on") setThreadMode(root, "full");
+    if (command === "off") setThreadMode(root, "metadata");
+    if (!config.enabled) {
+      commandOutput("LangSmith tracing is disabled by configuration for this thread.");
+    } else {
+      commandOutput(
+        getThreadMode(root) === "full"
+          ? "LangSmith tracing is on for this thread."
+          : "LangSmith tracing is off for this thread (metadata only).",
+      );
+    }
+    return true;
+  }
+  try {
+    if (input.turn_id != null) snapshotCurrentTurnMode(root, input.turn_id);
+    else enqueuePendingMode(root);
+  } catch {}
 
-  // Skip entirely if tracing is disabled
-  if (!config.enabled) return;
+  return false;
+}
 
-  // Redact secrets before upload (on by default). The anonymizer is set on the
-  // single Client, so it also covers replica destinations, which reuse it.
+async function handleStop(content: StopInput) {
+  const config = await getConfig();
+  if (!config.enabled || content.transcript_path == null) return;
   const anonymizer = config.redact
     ? createSecretAnonymizer(
         config.redact_extra_rules ? { extraRules: config.redact_extra_rules } : undefined,
       )
     : undefined;
-
-  const client = new Client({
-    apiKey: config.api_key,
-    apiUrl: config.api_url,
-    anonymizer,
-  });
-
-  // (Optionally) reconstruct the distributed parent so Codex runs attach to the target trace.
-  const parentRunTree = config.parent_headers
-    ? RunTree.fromHeaders(config.parent_headers, {
-        client,
-        project_name: config.project,
-      })
+  const client = new Client({ apiKey: config.api_key, apiUrl: config.api_url, anonymizer });
+  const traceHeader = config.parent_headers?.["langsmith-trace"];
+  const parentRunTree = traceHeader
+    ? RunTree.fromHeaders(config.parent_headers!, { client, project_name: config.project })
     : undefined;
+  await convertToRunTree(
+    { transcript_path: content.transcript_path, turn_id: content.turn_id ?? null },
+    {
+      client,
+      projectName: config.project,
+      metadata: config.metadata,
+      replicas: config.replicas,
+      parentRunTree,
+      failClosedMissingSnapshot: true,
+    },
+  );
+}
 
-  await convertToRunTree(content, {
-    client,
-    projectName: config.project,
-    metadata: config.metadata,
-    replicas: config.replicas,
-    parentRunTree,
-  });
+export async function runHook() {
+  const content = await readStdin<HookInput>();
+  if (content.hook_event_name === "UserPromptSubmit") await handleUserPromptSubmit(content);
+  else await handleStop(content);
 }
 
 runHook();

--- a/plugins/tracing/src/state.ts
+++ b/plugins/tracing/src/state.ts
@@ -1,0 +1,328 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export type TracingMode = "full" | "metadata";
+type TurnMode = TracingMode | "skip";
+type TimedMode = { mode: TurnMode; root: string; updatedAt: number };
+type TimedRoot = { root: string; updatedAt: number };
+type PendingSnapshot = { createdAt: number };
+type TracingState = {
+  version: 2;
+  threads: Record<string, { tracing?: "metadata"; updatedAt: number }>;
+  turns: Record<string, TimedMode>;
+  roots: Record<string, TimedRoot>;
+  pending: Record<string, PendingSnapshot[]>;
+};
+
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const emptyState = (): TracingState => ({
+  version: 2,
+  threads: {},
+  turns: {},
+  roots: {},
+  pending: {},
+});
+const sleep = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+
+function statePath(home = process.env.HOME ?? os.homedir()) {
+  return path.join(home, ".codex", "langsmith-state.json");
+}
+
+function parseState(data: string): TracingState | undefined {
+  try {
+    const value = JSON.parse(data) as Record<string, unknown>;
+    if (value == null || typeof value !== "object" || Array.isArray(value)) return undefined;
+    const pending = value.pending ?? {};
+    for (const entry of [value.threads, value.turns, value.roots, pending]) {
+      if (entry == null || typeof entry !== "object" || Array.isArray(entry)) return undefined;
+    }
+    if (value.version !== 2) return undefined;
+    const state = { ...value, pending } as TracingState;
+    if (
+      Object.values(state.threads).some(
+        (entry) =>
+          entry == null ||
+          typeof entry !== "object" ||
+          Array.isArray(entry) ||
+          typeof entry.updatedAt !== "number" ||
+          (entry.tracing != null && entry.tracing !== "metadata"),
+      )
+    )
+      return undefined;
+    if (
+      Object.values(state.turns).some(
+        (entry) =>
+          entry == null ||
+          typeof entry !== "object" ||
+          !["full", "metadata", "skip"].includes(entry.mode) ||
+          typeof entry.root !== "string" ||
+          typeof entry.updatedAt !== "number",
+      )
+    )
+      return undefined;
+    if (
+      Object.values(state.roots).some(
+        (entry) =>
+          entry == null ||
+          typeof entry !== "object" ||
+          typeof entry.root !== "string" ||
+          typeof entry.updatedAt !== "number",
+      )
+    )
+      return undefined;
+    if (
+      Object.values(state.pending).some(
+        (queue) =>
+          !Array.isArray(queue) ||
+          queue.some(
+            (entry) =>
+              entry == null || typeof entry !== "object" || typeof entry.createdAt !== "number",
+          ),
+      )
+    )
+      return undefined;
+    return state;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readTracingState(home?: string): { state: TracingState; malformed: boolean } {
+  try {
+    const parsed = parseState(fs.readFileSync(statePath(home), "utf8"));
+    return parsed == null
+      ? { state: emptyState(), malformed: true }
+      : { state: parsed, malformed: false };
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { state: emptyState(), malformed: false }
+      : { state: emptyState(), malformed: true };
+  }
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function staleLock(lock: string): boolean {
+  try {
+    const owner = JSON.parse(fs.readFileSync(path.join(lock, "owner.json"), "utf8")) as {
+      pid?: unknown;
+      created?: unknown;
+    };
+    return (
+      typeof owner.pid !== "number" ||
+      typeof owner.created !== "number" ||
+      Date.now() - owner.created > 30_000 ||
+      !processAlive(owner.pid)
+    );
+  } catch {
+    try {
+      return Date.now() - fs.statSync(lock).mtimeMs > 30_000;
+    } catch {
+      return true;
+    }
+  }
+}
+
+function rootForThread(state: TracingState, threadId: string): string {
+  let current = threadId;
+  const seen = new Set<string>();
+  while (state.roots[current] != null && !seen.has(current)) {
+    seen.add(current);
+    current = state.roots[current].root;
+  }
+  return current;
+}
+
+function collectRoot(state: TracingState, root: string): void {
+  delete state.threads[root];
+  delete state.pending[root];
+  for (const [turnId, entry] of Object.entries(state.turns)) {
+    if (entry.root === root) delete state.turns[turnId];
+  }
+  for (const [threadId, entry] of Object.entries(state.roots)) {
+    if (threadId === root || rootForThread(state, threadId) === root) delete state.roots[threadId];
+  }
+}
+
+function gc(state: TracingState, now: number): void {
+  const cutoff = now - RETENTION_MS;
+  const activeRoots = new Set<string>();
+  for (const [root, entry] of Object.entries(state.threads)) {
+    if (entry.updatedAt >= cutoff) activeRoots.add(root);
+  }
+  for (const entry of Object.values(state.turns)) {
+    if (entry.updatedAt >= cutoff) activeRoots.add(entry.root);
+  }
+  for (const [thread, entry] of Object.entries(state.roots)) {
+    if (entry.updatedAt >= cutoff) activeRoots.add(rootForThread(state, thread));
+  }
+  for (const [root, queue] of Object.entries(state.pending)) {
+    state.pending[root] = queue.filter((entry) => entry.createdAt >= cutoff);
+    if (state.pending[root].length > 0) activeRoots.add(root);
+    else delete state.pending[root];
+  }
+  const roots = new Set([
+    ...Object.keys(state.threads),
+    ...Object.values(state.turns).map((entry) => entry.root),
+    ...Object.keys(state.pending),
+    ...Object.keys(state.roots).map((thread) => rootForThread(state, thread)),
+  ]);
+  for (const root of roots) if (!activeRoots.has(root)) collectRoot(state, root);
+}
+
+function withLock<T>(
+  home: string | undefined,
+  update: (state: TracingState, now: number) => T,
+  recoverMalformed = false,
+): T {
+  const file = statePath(home);
+  const dir = path.dirname(file);
+  const lock = path.join(dir, "langsmith-state.lock");
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      fs.mkdirSync(lock, { mode: 0o700 });
+      fs.writeFileSync(
+        path.join(lock, "owner.json"),
+        JSON.stringify({ pid: process.pid, created: Date.now() }),
+      );
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (staleLock(lock)) {
+        fs.rmSync(lock, { recursive: true, force: true });
+        continue;
+      }
+      if (attempt >= 200) throw new Error("Timed out waiting for LangSmith tracing state lock");
+      sleep();
+    }
+  }
+  try {
+    const loaded = readTracingState(home);
+    if (loaded.malformed && !recoverMalformed) throw new Error("Malformed LangSmith tracing state");
+    if (loaded.malformed && fs.existsSync(file)) {
+      fs.renameSync(file, `${file}.corrupt-${Date.now()}-${process.pid}`);
+    }
+    const state = loaded.malformed ? emptyState() : loaded.state;
+    const now = Date.now();
+    gc(state, now);
+    const result = update(state, now);
+    const temp = path.join(dir, `.langsmith-state-${process.pid}-${Date.now()}.tmp`);
+    fs.writeFileSync(temp, JSON.stringify(state), { mode: 0o600 });
+    fs.renameSync(temp, file);
+    return result;
+  } finally {
+    fs.rmSync(lock, { recursive: true, force: true });
+  }
+}
+
+function modeInState(state: TracingState, threadId: string): TracingMode {
+  return state.threads[rootForThread(state, threadId)]?.tracing === "metadata"
+    ? "metadata"
+    : "full";
+}
+
+export function getThreadMode(threadId: string, home?: string): TracingMode {
+  const loaded = readTracingState(home);
+  return loaded.malformed ? "metadata" : modeInState(loaded.state, threadId);
+}
+
+export function setThreadMode(threadId: string, mode: TracingMode, home?: string): void {
+  withLock(
+    home,
+    (state, now) => {
+      const root = rootForThread(state, threadId);
+      state.threads[root] = {
+        ...(mode === "metadata" ? { tracing: "metadata" as const } : {}),
+        updatedAt: now,
+      };
+    },
+    true,
+  );
+}
+
+export function linkThreadRoot(threadId: string, rootId: string, home?: string): void {
+  withLock(home, (state, now) => {
+    const oldMode = modeInState(state, threadId);
+    const root = rootForThread(state, rootId);
+    state.roots[threadId] = { root, updatedAt: now };
+    if (oldMode === "metadata") state.threads[root] = { tracing: "metadata", updatedAt: now };
+  });
+}
+
+export function enqueuePendingMode(threadId: string, home?: string): void {
+  withLock(home, (state, now) => {
+    const root = rootForThread(state, threadId);
+    (state.pending[root] ??= []).push({ createdAt: now });
+  });
+}
+
+export function snapshotCurrentTurnMode(
+  threadId: string,
+  turnId: string,
+  home?: string,
+): TracingMode {
+  return withLock(home, (state, now) => {
+    const existing = state.turns[turnId];
+    if (existing != null) return existing.mode === "full" ? "full" : "metadata";
+    const root = rootForThread(state, threadId);
+    const mode = modeInState(state, root);
+    state.turns[turnId] = { mode, root, updatedAt: now };
+    return mode;
+  });
+}
+
+export function snapshotTurnMode(
+  threadId: string,
+  turnId: string,
+  inheritedMode?: TracingMode,
+  home?: string,
+): TracingMode {
+  return withLock(home, (state, now) => {
+    const existing = state.turns[turnId];
+    if (existing != null) return existing.mode === "full" ? "full" : "metadata";
+    const root = rootForThread(state, threadId);
+    const queue = state.pending[root];
+    if (queue != null) {
+      queue.shift();
+      if (queue.length === 0) delete state.pending[root];
+    }
+    const mode = inheritedMode ?? "metadata";
+    state.turns[turnId] = { mode, root, updatedAt: now };
+    return mode;
+  });
+}
+
+export function markTurnHandled(turnId: string, home?: string): void {
+  withLock(home, (state, now) => {
+    const existing = state.turns[turnId];
+    state.turns[turnId] = {
+      mode: "skip",
+      root: existing?.root ?? "unknown",
+      updatedAt: now,
+    };
+  });
+}
+
+export function isTurnHandled(turnId: string, home?: string): boolean {
+  const loaded = readTracingState(home);
+  return !loaded.malformed && loaded.state.turns[turnId]?.mode === "skip";
+}
+
+export function getTurnMode(
+  turnId: string | undefined,
+  _threadId: string,
+  home?: string,
+): TracingMode {
+  const loaded = readTracingState(home);
+  if (loaded.malformed || turnId == null) return "metadata";
+  return loaded.state.turns[turnId]?.mode === "full" ? "full" : "metadata";
+}

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -7,6 +7,15 @@ import * as os from "node:os";
 import { findLast } from "./utils/findLast.js";
 import { loadUploadedTurnIds, markTurnUploaded } from "./sidecar.js";
 import { codingAgentMetadata, resolveGitInfo } from "./metadata.js";
+import {
+  getThreadMode,
+  getTurnMode,
+  isTurnHandled,
+  linkThreadRoot,
+  markTurnHandled,
+  snapshotTurnMode,
+  type TracingMode,
+} from "./state.js";
 import type {
   Session,
   TokenCount,
@@ -391,6 +400,8 @@ async function postTurn(
 
       parentRunTree?: RunTree;
       debugNow?: { now: number; startTime: number };
+      turnMode?: TracingMode;
+      failClosedMissingSnapshot?: boolean;
     };
   },
 ) {
@@ -475,43 +486,93 @@ async function postTurn(
     git,
     sandboxType,
   });
+  const mode =
+    options?.turnMode ??
+    getTurnMode(task.turnId?.id, conversationThreadId ?? sessionMeta?.session_id ?? "");
+  const status = task.error == null ? "completed" : "error";
+  const safeBase = Object.fromEntries(
+    Object.entries(base).filter(
+      ([key]) =>
+        key === "thread_id" ||
+        key === "turn_id" ||
+        key === "turn_number" ||
+        key.startsWith("ls_agent_") ||
+        key === "ls_integration" ||
+        key === "ls_integration_version" ||
+        key === "ls_trace_schema_version",
+    ),
+  );
+  const metadataBase = {
+    ...safeBase,
+    status,
+    ls_tracing_mode: "metadata",
+  };
 
   // Scope-restricted keys: approval_policy on root only, ls_subagent_* on
   // subagent only. Set undefined elsewhere to override inherited values.
+  const safeReplicas =
+    mode === "metadata"
+      ? options?.replicas?.map((replica) => {
+          if (Array.isArray(replica)) return replica;
+          const { updates: _, ...safe } = replica;
+          return safe;
+        })
+      : options?.replicas;
+  const topologyParent =
+    mode === "metadata" && options?.parentRunTree != null
+      ? new RunTree({
+          name: "distributed-parent",
+          id: options.parentRunTree.id,
+          trace_id: options.parentRunTree.trace_id,
+          dotted_order: options.parentRunTree.dotted_order,
+          client: options.client,
+          project_name: options.projectName,
+          inputs: {},
+          outputs: {},
+          extra: { metadata: {} },
+          replicas: safeReplicas,
+        })
+      : options?.parentRunTree;
+
   const parentConfig: RunTreeConfig = {
     name: "openai.codex",
     client: options?.client,
     project_name: options?.projectName,
     run_type: "chain",
-    replicas: options?.replicas,
-    inputs: { messages: user != null ? [user.message] : [] },
-    outputs: { messages: agent.map((i) => i.message) },
-    error: task.error,
+    replicas: safeReplicas,
+    inputs: mode === "metadata" ? {} : { messages: user != null ? [user.message] : [] },
+    outputs: mode === "metadata" ? {} : { messages: agent.map((i) => i.message) },
+    error: mode === "metadata" ? undefined : task.error,
     start_time: parentStartTime,
     end_time: parentEndTime,
     extra: {
-      metadata: {
-        ...options?.metadata,
-        ...task.context,
-        ...base,
-        ...(task.isErrorInterrupt ? { ls_is_error_interrupt: true } : {}),
-
-        approval_policy: isSubagent ? undefined : approvalPolicy,
-        ls_subagent_id: isSubagent ? sessionMeta?.session_id : undefined,
-        ls_subagent_type: isSubagent
-          ? (sessionMeta?.agent_role ?? sessionMeta?.agent_nickname)
-          : undefined,
-
-        codex_cli_version: sessionMeta?.cli_version,
-        ls_message_format: "anthropic",
-
-        // Non-reserved key: backend auto-aggregates child llm usage into the
-        // parent, so usage_metadata here would double-count.
-        ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
-      },
+      metadata:
+        mode === "metadata"
+          ? {
+              ...metadataBase,
+              ls_subagent_id: isSubagent ? sessionMeta?.session_id : undefined,
+              ls_subagent_type: isSubagent
+                ? (sessionMeta?.agent_role ?? sessionMeta?.agent_nickname)
+                : undefined,
+              ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
+            }
+          : {
+              ...options?.metadata,
+              ...task.context,
+              ...base,
+              ...(task.isErrorInterrupt ? { ls_is_error_interrupt: true } : {}),
+              approval_policy: isSubagent ? undefined : approvalPolicy,
+              ls_subagent_id: isSubagent ? sessionMeta?.session_id : undefined,
+              ls_subagent_type: isSubagent
+                ? (sessionMeta?.agent_role ?? sessionMeta?.agent_nickname)
+                : undefined,
+              codex_cli_version: sessionMeta?.cli_version,
+              ls_message_format: "anthropic",
+              ls_raw_aggregated_usage: getUsageMetadata(task.tokenCount?.total_token_usage),
+            },
     },
   };
-  const parent = options?.parentRunTree?.createChild(parentConfig) ?? new RunTree(parentConfig);
+  const parent = topologyParent?.createChild(parentConfig) ?? new RunTree(parentConfig);
 
   PROMISE_QUEUE.push(parent.postRun());
 
@@ -560,7 +621,7 @@ async function postTurn(
 
     await convertToRunTree(
       { transcript_path: subagentFile, turn_id: lastEvent?.payload.turn_id ?? null },
-      { ...options, parentRunTree: parent, debugNow },
+      { ...options, parentRunTree: parent, debugNow, turnMode: mode },
     );
   }
 
@@ -588,19 +649,27 @@ async function postTurn(
       run_type: "llm",
       start_time: outputStartTime,
       end_time: outputEndTime,
-      inputs: { messages: inputMessages.map((i) => i.message) },
-      outputs: { messages: aiMessage.map((i) => i.message) },
+      inputs: mode === "metadata" ? {} : { messages: inputMessages.map((i) => i.message) },
+      outputs: mode === "metadata" ? {} : { messages: aiMessage.map((i) => i.message) },
       extra: {
-        metadata: {
-          ...options?.metadata,
-          ...base,
-          ...CHILD_SCOPE_RESET,
-          ls_model_type: "chat",
-          ls_provider: sessionMeta?.model_provider,
-          ls_model_name: task.context?.model,
-          ls_invocation_params: task.context,
-          usage_metadata: getUsageMetadata(tokenCounts),
-        },
+        metadata:
+          mode === "metadata"
+            ? {
+                ...metadataBase,
+                ...CHILD_SCOPE_RESET,
+                ls_model_name: task.context?.model,
+                usage_metadata: getUsageMetadata(tokenCounts),
+              }
+            : {
+                ...options?.metadata,
+                ...base,
+                ...CHILD_SCOPE_RESET,
+                ls_model_type: "chat",
+                ls_provider: sessionMeta?.model_provider,
+                ls_model_name: task.context?.model,
+                ls_invocation_params: task.context,
+                usage_metadata: getUsageMetadata(tokenCounts),
+              },
       },
     });
     PROMISE_QUEUE.push(llmChild.postRun());
@@ -642,24 +711,33 @@ async function postTurn(
         run_type: "tool",
         start_time: min,
         end_time: max,
-        inputs: { input: msgToolCall.args },
-        outputs: { ...toolCall.outputs, messages: [toolMessage.message] },
-        error: toolCall.error,
+        inputs: mode === "metadata" ? {} : { input: msgToolCall.args },
+        outputs:
+          mode === "metadata" ? {} : { ...toolCall.outputs, messages: [toolMessage.message] },
+        error: mode === "metadata" ? undefined : toolCall.error,
         extra: {
-          metadata: {
-            ...options?.metadata,
-            ...base,
-            ...CHILD_SCOPE_RESET,
-            ls_model_type: "chat",
-            ls_provider: sessionMeta?.model_provider,
-            ls_model_name: task.context?.model,
-            ls_invocation_params: task.context,
-            usage_metadata: getUsageMetadata(toolMessage.tokenCount),
-            // Native tool name, only when it differs from the run name.
-            ...(nativeToolName != null && runName !== nativeToolName
-              ? { ls_tool_name: nativeToolName }
-              : {}),
-          },
+          metadata:
+            mode === "metadata"
+              ? {
+                  ...metadataBase,
+                  ...CHILD_SCOPE_RESET,
+                  ls_model_name: task.context?.model,
+                  ls_tool_name: nativeToolName,
+                  usage_metadata: getUsageMetadata(toolMessage.tokenCount),
+                }
+              : {
+                  ...options?.metadata,
+                  ...base,
+                  ...CHILD_SCOPE_RESET,
+                  ls_model_type: "chat",
+                  ls_provider: sessionMeta?.model_provider,
+                  ls_model_name: task.context?.model,
+                  ls_invocation_params: task.context,
+                  usage_metadata: getUsageMetadata(toolMessage.tokenCount),
+                  ...(nativeToolName != null && runName !== nativeToolName
+                    ? { ls_tool_name: nativeToolName }
+                    : {}),
+                },
         },
       });
       PROMISE_QUEUE.push(toolRun.postRun());
@@ -674,6 +752,7 @@ async function postTurn(
   for (const subagentThread of task.subagentThreads) {
     await postSubagentThread(subagentThread);
   }
+  await Promise.all(PROMISE_QUEUE.splice(0));
 }
 
 export async function convertToRunTree(
@@ -686,6 +765,8 @@ export async function convertToRunTree(
     projectName?: string;
     sessionsRoot?: string;
     debugNow?: { now: number; startTime: number };
+    turnMode?: TracingMode;
+    failClosedMissingSnapshot?: boolean;
   },
 ) {
   let sessionMeta: Session | undefined;
@@ -741,6 +822,13 @@ export async function convertToRunTree(
         threadSpawn != null ||
         (payload.thread_source === "subagent" && typeof payload.parent_thread_id === "string");
 
+      const parentThreadId = threadSpawn?.parent_thread_id ?? payload.parent_thread_id ?? undefined;
+      if (isSubagent && parentThreadId != null) {
+        try {
+          linkThreadRoot(payload.id, parentThreadId);
+        } catch {}
+      }
+
       sessionMeta = {
         session_id: payload.id,
         model_provider: payload.model_provider ?? undefined,
@@ -749,7 +837,7 @@ export async function convertToRunTree(
         cwd: payload.cwd,
         git: payload.git,
         is_subagent: isSubagent,
-        parent_thread_id: threadSpawn?.parent_thread_id ?? payload.parent_thread_id ?? undefined,
+        parent_thread_id: parentThreadId,
         agent_role: threadSpawn?.agent_role ?? payload.agent_role ?? undefined,
         agent_nickname: threadSpawn?.agent_nickname ?? payload.agent_nickname ?? undefined,
       };
@@ -802,6 +890,15 @@ export async function convertToRunTree(
         turnNumber += 1;
         task.turnId = { id: payload.turn_id, timestamp: eventTime };
         task.turnNumber = turnNumber;
+        if (sessionMeta != null) {
+          try {
+            snapshotTurnMode(
+              sessionMeta.parent_thread_id ?? sessionMeta.session_id,
+              payload.turn_id,
+              options?.turnMode,
+            );
+          } catch {}
+        }
       }
 
       if (typeof payload.call_id === "string") {
@@ -904,11 +1001,27 @@ export async function convertToRunTree(
           turnNumber += 1;
           task.turnNumber = turnNumber;
         }
-        if (completedTurnId == null || !uploadedTurnIds.has(completedTurnId)) {
-          await postTurn(task, sessionMeta, { rolloutFile: input.transcript_path, options });
+        if (
+          completedTurnId == null ||
+          (!uploadedTurnIds.has(completedTurnId) && !isTurnHandled(completedTurnId))
+        ) {
+          const threadId = sessionMeta?.parent_thread_id ?? sessionMeta?.session_id ?? "";
+          const mode =
+            options?.turnMode ??
+            (options?.failClosedMissingSnapshot
+              ? getTurnMode(completedTurnId, threadId)
+              : getThreadMode(threadId));
+          await postTurn(task, sessionMeta, {
+            rolloutFile: input.transcript_path,
+            options: { ...options, turnMode: mode },
+          });
           if (completedTurnId != null) {
             uploadedTurnIds.add(completedTurnId);
-            await markTurnUploaded(input.transcript_path, completedTurnId);
+            if (mode === "metadata") {
+              try {
+                markTurnHandled(completedTurnId);
+              } catch {}
+            } else await markTurnUploaded(input.transcript_path, completedTurnId);
           }
         }
         task = undefined;

--- a/plugins/tracing/test/command.test.ts
+++ b/plugins/tracing/test/command.test.ts
@@ -1,0 +1,89 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { vol } from "memfs";
+import { beforeEach, expect, it, vi } from "vitest";
+import { handleUserPromptSubmit } from "../src/index.js";
+import { getThreadMode, getTurnMode, readTracingState } from "../src/state.js";
+
+vi.mock("node:fs", async () => {
+  const { fs } = await import("memfs");
+  return fs;
+});
+vi.mock("../src/utils/stdin.js", () => ({ readStdin: () => new Promise(() => {}) }));
+
+const HOME = "/home/codex-user";
+const FILE = path.join(HOME, ".codex/sessions/rollout-root.jsonl");
+
+function input(prompt: string, turn_id: string | null = "turn") {
+  return {
+    session_id: "root",
+    ...(turn_id === null ? {} : { turn_id }),
+    transcript_path: FILE,
+    hook_event_name: "UserPromptSubmit" as const,
+    prompt,
+  };
+}
+
+beforeEach(() => {
+  vol.reset();
+  vi.stubEnv("HOME", HOME);
+  vi.stubEnv("TRACE_TO_LANGSMITH", "true");
+  vol.fromJSON({
+    [FILE]: JSON.stringify({ type: "session_meta", payload: { id: "root", source: "cli" } }),
+  });
+});
+
+it("blocks exact commands with the Codex command payload and standard messages", async () => {
+  const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  await expect(handleUserPromptSubmit(input("/trace off"))).resolves.toBe(true);
+  expect(getThreadMode("root", HOME)).toBe("metadata");
+  expect(write).toHaveBeenLastCalledWith(
+    JSON.stringify({
+      decision: "block",
+      reason: "LangSmith tracing is off for this thread (metadata only).",
+    }),
+  );
+  await handleUserPromptSubmit(input("/trace on"));
+  expect(write).toHaveBeenLastCalledWith(
+    JSON.stringify({ decision: "block", reason: "LangSmith tracing is on for this thread." }),
+  );
+  write.mockRestore();
+});
+
+it("persists commands but reports a distinct master-disabled state", async () => {
+  vi.stubEnv("TRACE_TO_LANGSMITH", "false");
+  const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  await handleUserPromptSubmit(input("/trace off"));
+  expect(getThreadMode("root", HOME)).toBe("metadata");
+  expect(write).toHaveBeenCalledWith(
+    JSON.stringify({
+      decision: "block",
+      reason: "LangSmith tracing is disabled by configuration for this thread.",
+    }),
+  );
+  write.mockRestore();
+});
+
+it("does not intercept near matches and snapshots normal prompts", async () => {
+  await expect(handleUserPromptSubmit(input(" /trace off", "turn-1"))).resolves.toBe(false);
+  expect(getTurnMode("turn-1", "root", HOME)).toBe("full");
+  await expect(handleUserPromptSubmit(input("/trace OFF", "turn-2"))).resolves.toBe(false);
+  expect(getTurnMode("turn-2", "root", HOME)).toBe("full");
+});
+
+it("fails closed when the prompt snapshot cannot be written", async () => {
+  const rename = vi.spyOn(fs, "renameSync").mockImplementation(() => {
+    throw new Error("write failed");
+  });
+  await expect(handleUserPromptSubmit(input("private", "missing"))).resolves.toBe(false);
+  rename.mockRestore();
+  expect(getTurnMode("missing", "root", HOME)).toBe("metadata");
+});
+
+it("queues prompts without turn ids and never queues commands", async () => {
+  await handleUserPromptSubmit(input("private prompt", null));
+  expect(readTracingState(HOME).state.pending.root).toHaveLength(1);
+  expect(JSON.stringify(readTracingState(HOME).state)).not.toContain("private prompt");
+  await handleUserPromptSubmit(input("/trace status", null));
+  expect(readTracingState(HOME).state.pending.root).toHaveLength(1);
+});

--- a/plugins/tracing/test/config.test.ts
+++ b/plugins/tracing/test/config.test.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 
-import { vol } from "memfs";
+import { fs, vol } from "memfs";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { getConfig } from "../src/config.js";
 
@@ -22,8 +22,12 @@ function writeConfigFiles(files: {
   local?: Partial<Record<string, unknown>>;
 }) {
   vol.fromJSON({
-    [path.join(HOME, ".codex", "langsmith.json")]: JSON.stringify(files.global),
-    [path.join(CWD, ".codex", "langsmith.json")]: JSON.stringify(files.local),
+    ...(files.global == null
+      ? {}
+      : { [path.join(HOME, ".codex", "langsmith.json")]: JSON.stringify(files.global) }),
+    ...(files.local == null
+      ? {}
+      : { [path.join(CWD, ".codex", "langsmith.json")]: JSON.stringify(files.local) }),
   });
 }
 
@@ -87,7 +91,7 @@ it("loads environment config", async () => {
   vi.stubEnv("LANGSMITH_METADATA", JSON.stringify({ source: "env" }));
   vi.stubEnv(
     "LANGSMITH_RUNS_ENDPOINTS",
-    JSON.stringify([{ api_url: "https://env-replica.example" }]),
+    JSON.stringify([{ apiUrl: "https://env-replica.example" }]),
   );
   vi.stubEnv("LANGSMITH_CODEX_PARENT_HEADERS", JSON.stringify(parentHeaders));
   const config = await getConfig({ home: HOME, cwd: CWD, env: process.env });
@@ -97,7 +101,7 @@ it("loads environment config", async () => {
     api_url: "https://env.example",
     project: "env-project",
     metadata: { source: "env" },
-    replicas: [{ api_url: "https://env-replica.example" }],
+    replicas: [{ apiUrl: "https://env-replica.example" }],
     parent_headers: parentHeaders,
     redact: true,
   });
@@ -111,14 +115,14 @@ it("applies local config over global config", async () => {
       api_url: "https://global.example",
       project: "global-project",
       metadata: { scope: "global" },
-      replicas: [{ api_url: "https://global-replica.example" }],
+      replicas: [{ apiUrl: "https://global-replica.example" }],
     },
     local: {
       api_key: "local-key",
       api_url: "https://local.example",
       project: "local-project",
       metadata: { scope: "local" },
-      replicas: [{ api_url: "https://local-replica.example" }],
+      replicas: [{ apiUrl: "https://local-replica.example" }],
     },
   });
 
@@ -129,7 +133,7 @@ it("applies local config over global config", async () => {
     api_url: "https://local.example",
     project: "local-project",
     metadata: { scope: "local" },
-    replicas: [{ api_url: "https://local-replica.example" }],
+    replicas: [{ apiUrl: "https://local-replica.example" }],
     redact: true,
   });
 });
@@ -157,7 +161,7 @@ it("applies environment values over config files", async () => {
   vi.stubEnv("LANGSMITH_METADATA", JSON.stringify({ source: "env" }));
   vi.stubEnv(
     "LANGSMITH_RUNS_ENDPOINTS",
-    JSON.stringify([{ api_url: "https://env-replica.example" }]),
+    JSON.stringify([{ apiUrl: "https://env-replica.example" }]),
   );
 
   const config = await getConfig({ home: HOME, cwd: CWD, env: process.env });
@@ -167,7 +171,7 @@ it("applies environment values over config files", async () => {
     api_url: "https://env.example",
     project: "env-project",
     metadata: { source: "env" },
-    replicas: [{ api_url: "https://env-replica.example" }],
+    replicas: [{ apiUrl: "https://env-replica.example" }],
     redact: true,
   });
 });
@@ -189,11 +193,11 @@ it("prefers Codex-specific environment values over standard LangSmith values", a
 
   vi.stubEnv(
     "LANGSMITH_RUNS_ENDPOINTS",
-    JSON.stringify([{ api_url: "https://standard-replica.example" }]),
+    JSON.stringify([{ apiUrl: "https://standard-replica.example" }]),
   );
   vi.stubEnv(
     "LANGSMITH_CODEX_RUNS_ENDPOINTS",
-    JSON.stringify([{ api_url: "https://codex-replica.example" }]),
+    JSON.stringify([{ apiUrl: "https://codex-replica.example" }]),
   );
 
   const config = await getConfig({ home: HOME, cwd: CWD, env: process.env });
@@ -203,7 +207,7 @@ it("prefers Codex-specific environment values over standard LangSmith values", a
     api_url: "https://codex.example",
     project: "codex-project",
     metadata: { source: "codex" },
-    replicas: [{ api_url: "https://codex-replica.example" }],
+    replicas: [{ apiUrl: "https://codex-replica.example" }],
     redact: true,
   });
 });
@@ -249,31 +253,70 @@ it("falls back to defaults when an env value fails schema validation", async () 
   expect(config).toEqual({ enabled: false, project: "codex", redact: true });
 });
 
-it("normalizes replica camelCase aliases", async () => {
+it("fails disabled for malformed project config and invalid present environment values", async () => {
+  vol.fromJSON({
+    [path.join(CWD, ".codex", "langsmith.json")]: "not json",
+  });
+  vi.stubEnv("TRACE_TO_LANGSMITH", "true");
+  expect(await getConfig({ home: HOME, cwd: CWD, env: process.env })).toMatchObject({
+    enabled: false,
+  });
+
+  vol.reset();
+  vi.stubEnv("LANGSMITH_CODEX_METADATA", "not json");
+  expect(await getConfig({ home: HOME, cwd: CWD, env: process.env })).toMatchObject({
+    enabled: false,
+  });
+});
+
+it("normalizes replicas to the installed SDK WriteReplica shape", async () => {
   vi.stubEnv(
     "LANGSMITH_CODEX_RUNS_ENDPOINTS",
     JSON.stringify([
       {
-        apiUrl: "https://replica.example",
-        apiKey: "replica-key",
-        projectName: "replica-project",
+        api_url: "https://replica.example",
+        api_key: "replica-key",
+        project: "replica-project",
+        workspace_id: "workspace",
+        primary: true,
+        from_env: false,
+        reroot: true,
         updates: { mode: "append" },
+        unsupported: "drop-me",
       },
     ]),
   );
 
   const config = await getConfig({ home: HOME, cwd: CWD, env: process.env });
-  expect(config).toEqual({
+  expect(config.replicas).toEqual([
+    {
+      apiUrl: "https://replica.example",
+      apiKey: "replica-key",
+      projectName: "replica-project",
+      workspaceId: "workspace",
+      primary: true,
+      fromEnv: false,
+      reroot: true,
+      updates: { mode: "append" },
+    },
+  ]);
+});
+
+it("fails disabled when the config path is a directory", async () => {
+  writeConfigFiles({ global: { enabled: true } });
+  vol.mkdirSync(path.join(CWD, ".codex", "langsmith.json"), { recursive: true });
+  expect(await getConfig({ home: HOME, cwd: CWD, env: process.env })).toMatchObject({
     enabled: false,
-    project: "codex",
-    replicas: [
-      {
-        api_url: "https://replica.example",
-        api_key: "replica-key",
-        project: "replica-project",
-        updates: { mode: "append" },
-      },
-    ],
-    redact: true,
   });
+});
+
+it("fails disabled on non-ENOENT config read errors", async () => {
+  writeConfigFiles({ global: { enabled: true } });
+  const readFile = vi
+    .spyOn(fs.promises, "readFile")
+    .mockRejectedValueOnce(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+  expect(await getConfig({ home: HOME, cwd: CWD, env: process.env })).toMatchObject({
+    enabled: false,
+  });
+  readFile.mockRestore();
 });

--- a/plugins/tracing/test/privacy.test.ts
+++ b/plugins/tracing/test/privacy.test.ts
@@ -1,0 +1,198 @@
+import * as path from "node:path";
+import { vol } from "memfs";
+import { beforeEach, expect, it, vi } from "vitest";
+import { RunTree } from "langsmith";
+import { setThreadMode } from "../src/state.js";
+import { convertToRunTree } from "../src/trace.js";
+import { mockClient } from "./utils/mock_client.js";
+import { getAssumedTreeFromCalls } from "./utils/tree.js";
+
+vi.mock("node:fs/promises", async () => {
+  const { fs } = await import("memfs");
+  return fs.promises;
+});
+vi.mock("node:fs", async () => {
+  const { fs } = await import("memfs");
+  return fs;
+});
+
+const HOME = "/home/codex-user";
+const THREAD = "private-thread";
+const TURN = "private-turn";
+const FILE = path.join(HOME, ".codex/sessions/rollout-private-thread.jsonl");
+const ts = "2026-06-01T12:00:00.000Z";
+const line = (type: string, payload: Record<string, unknown>) =>
+  JSON.stringify({ timestamp: ts, type, payload });
+
+beforeEach(() => {
+  vol.reset();
+  vi.stubEnv("HOME", HOME);
+});
+
+it("serializes metadata runs with empty I/O and a strict safe allowlist", async () => {
+  vol.fromJSON({
+    [FILE]: [
+      line("session_meta", {
+        id: THREAD,
+        cwd: "/secret/repo",
+        cli_version: "1.0",
+        source: "cli",
+        model_provider: "secret-provider",
+        base_instructions: { text: "secret system" },
+      }),
+      line("event_msg", { type: "task_started", turn_id: TURN }),
+      line("turn_context", {
+        model: "gpt-safe",
+        cwd: "/secret/repo",
+        user_instructions: "secret custom",
+        task: "secret task",
+      }),
+      line("response_item", {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "secret user" }],
+      }),
+      line("response_item", {
+        type: "function_call",
+        name: "exec_command",
+        call_id: "call-1",
+        arguments: JSON.stringify({ cmd: "secret command" }),
+      }),
+      line("response_item", {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "secret result",
+      }),
+      line("event_msg", { type: "task_complete", turn_id: TURN, error: "secret error" }),
+    ].join("\n"),
+  });
+  setThreadMode(THREAD, "metadata", HOME);
+  const { client, callSpy } = mockClient();
+  await convertToRunTree({ transcript_path: FILE, turn_id: TURN }, { client });
+  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+  const serialized = JSON.stringify(tree);
+  for (const secret of [
+    "/secret/repo",
+    "secret-provider",
+    "secret system",
+    "secret custom",
+    "secret task",
+    "secret user",
+    "secret command",
+    "secret result",
+    "secret error",
+  ]) {
+    expect(serialized).not.toContain(secret);
+  }
+  for (const run of Object.values(tree.data)) {
+    expect(run.inputs).toEqual({});
+    expect(run.outputs).toEqual({});
+    expect(run.error).toBeUndefined();
+    expect(run.extra?.metadata?.ls_tracing_mode).toBe("metadata");
+  }
+});
+
+it("preserves distributed baggage in full mode", async () => {
+  vol.fromJSON({
+    [FILE]: [
+      line("session_meta", { id: THREAD, source: "cli" }),
+      line("event_msg", { type: "task_started", turn_id: TURN }),
+      line("response_item", {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "user" }],
+      }),
+      line("event_msg", { type: "task_complete", turn_id: TURN }),
+    ].join("\n"),
+  });
+  const { client, callSpy } = mockClient();
+  const parentRunTree = RunTree.fromHeaders(
+    {
+      "langsmith-trace": "20260601T120000000000Z11111111-1111-4111-8111-111111111111",
+      baggage: "langsmith-metadata=%7B%22preserved%22%3A%22baggage-value%22%7D",
+    },
+    { client },
+  );
+  await convertToRunTree(
+    { transcript_path: FILE, turn_id: TURN },
+    { client, parentRunTree, turnMode: "full" },
+  );
+  expect(
+    callSpy.mock.calls
+      .map((call: unknown[]) =>
+        new TextDecoder().decode((call.at(-1) as RequestInit).body as Uint8Array),
+      )
+      .join("\n"),
+  ).toContain("baggage-value");
+});
+
+it("does not serialize parent baggage metadata or replica updates in metadata mode", async () => {
+  vol.fromJSON({
+    [FILE]: [
+      line("session_meta", { id: THREAD, source: "cli" }),
+      line("event_msg", { type: "task_started", turn_id: TURN }),
+      line("response_item", {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "secret user" }],
+      }),
+      line("event_msg", { type: "task_complete", turn_id: TURN }),
+    ].join("\n"),
+  });
+  setThreadMode(THREAD, "metadata", HOME);
+  const { client, callSpy } = mockClient({ apiUrl: "https://master.example" });
+  const parentRunTree = RunTree.fromHeaders(
+    {
+      "langsmith-trace": "20260601T120000000000Z11111111-1111-4111-8111-111111111111",
+      baggage:
+        "langsmith-metadata=%7B%22hostile%22%3A%22parent-secret%22%7D,langsmith-tags=secret-tag,langsmith-project=secret-project",
+    },
+    { client },
+  );
+  await convertToRunTree(
+    { transcript_path: FILE, turn_id: TURN },
+    {
+      client,
+      parentRunTree,
+      replicas: [
+        {
+          apiUrl: "https://replica.invalid",
+          apiKey: "replica-key",
+          projectName: "safe-project",
+          updates: { metadata: { hostile: "replica-secret" }, inputs: { secret: true } },
+        },
+      ],
+    },
+  );
+  const bodies = callSpy.mock.calls.map((call: unknown[]) =>
+    String((call.at(-1) as RequestInit).body),
+  );
+  const serialized = bodies.join("\n");
+  const requests: { url: string; headers: Headers; init: RequestInit }[] = callSpy.mock.calls.map(
+    (call: unknown[]) => ({
+      url:
+        call[0] != null && typeof call[0] === "object" && "url" in call[0]
+          ? String(call[0].url)
+          : String(call[0]),
+      headers: new Headers([
+        ...(call[0] != null && typeof call[0] === "object" && "headers" in call[0]
+          ? (call[0].headers as Headers).entries()
+          : []),
+        ...new Headers((call.at(-1) as RequestInit).headers).entries(),
+      ]),
+      init: call.at(-1) as RequestInit,
+    }),
+  );
+  const replicaRequests = requests.filter(({ url }) => url.startsWith("https://replica.invalid/"));
+  expect(replicaRequests.length).toBeGreaterThan(0);
+  for (const { headers, init } of replicaRequests) {
+    expect(headers.get("x-api-key")).toBe("replica-key");
+    expect(new TextDecoder().decode(init.body as Uint8Array)).toContain("safe-project");
+  }
+  expect(serialized).not.toContain("parent-secret");
+  expect(serialized).not.toContain("secret-tag");
+  expect(serialized).not.toContain("secret-project");
+  expect(serialized).not.toContain("replica-secret");
+  expect(serialized).not.toContain('"secret":true');
+  expect(serialized).toContain([...new TextEncoder().encode(TURN)].join(","));
+});

--- a/plugins/tracing/test/state.test.ts
+++ b/plugins/tracing/test/state.test.ts
@@ -1,0 +1,99 @@
+import * as path from "node:path";
+import { vol } from "memfs";
+import { beforeEach, expect, it, vi } from "vitest";
+import {
+  enqueuePendingMode,
+  getThreadMode,
+  getTurnMode,
+  linkThreadRoot,
+  readTracingState,
+  setThreadMode,
+  snapshotCurrentTurnMode,
+  snapshotTurnMode,
+} from "../src/state.js";
+
+vi.mock("node:fs", async () => {
+  const { fs } = await import("memfs");
+  return fs;
+});
+
+const HOME = "/home/codex-user";
+const FILE = path.join(HOME, ".codex", "langsmith-state.json");
+
+beforeEach(() => vol.reset());
+
+it("persists sticky root mode without using thread ids as filenames", () => {
+  setThreadMode("root/thread", "metadata", HOME);
+  linkThreadRoot("child/thread", "root/thread", HOME);
+  expect(getThreadMode("child/thread", HOME)).toBe("metadata");
+  expect(Object.keys(vol.toJSON())).toEqual([FILE]);
+});
+
+it("keeps explicit current turn modes immutable across later mode changes", () => {
+  setThreadMode("root", "metadata", HOME);
+  expect(snapshotCurrentTurnMode("root", "turn-1", HOME)).toBe("metadata");
+  setThreadMode("root", "full", HOME);
+  expect(snapshotCurrentTurnMode("root", "turn-1", HOME)).toBe("metadata");
+  expect(snapshotCurrentTurnMode("root", "turn-2", HOME)).toBe("full");
+});
+
+it("fails closed without replacing malformed state and explicitly quarantines on recovery", () => {
+  vol.fromJSON({ [FILE]: "not json" });
+  expect(getThreadMode("root", HOME)).toBe("metadata");
+  expect(() => enqueuePendingMode("root", HOME)).toThrow();
+  expect(vol.readFileSync(FILE, "utf8")).toBe("not json");
+  setThreadMode("root", "full", HOME);
+  expect(readTracingState(HOME).malformed).toBe(false);
+  expect(Object.keys(vol.toJSON()).some((name) => name.includes(".corrupt-"))).toBe(true);
+});
+
+it("recovers dead locks", () => {
+  const lock = path.join(HOME, ".codex", "langsmith-state.lock");
+  vol.fromJSON({
+    [path.join(lock, "owner.json")]: JSON.stringify({ pid: 99999999, created: Date.now() }),
+  });
+  setThreadMode("root", "metadata", HOME);
+  expect(getThreadMode("root", HOME)).toBe("metadata");
+});
+
+it("uses compatibility FIFO only as metadata markers and never backfills full", () => {
+  setThreadMode("root", "full", HOME);
+  enqueuePendingMode("root", HOME);
+  enqueuePendingMode("root", HOME);
+  expect(snapshotTurnMode("root", "stale", undefined, HOME)).toBe("metadata");
+  expect(snapshotTurnMode("root", "new", undefined, HOME)).toBe("metadata");
+  expect(snapshotTurnMode("root", "unmatched", undefined, HOME)).toBe("metadata");
+});
+
+it("defaults newly parsed turns to metadata after an off transition", () => {
+  snapshotCurrentTurnMode("root", "before", HOME);
+  setThreadMode("root", "metadata", HOME);
+  expect(snapshotTurnMode("root", "after", undefined, HOME)).toBe("metadata");
+  expect(getTurnMode("before", "root", HOME)).toBe("full");
+});
+
+it("conservatively keeps metadata mode when a root mapping migrates", () => {
+  setThreadMode("child", "metadata", HOME);
+  linkThreadRoot("child", "root", HOME);
+  expect(getThreadMode("root", HOME)).toBe("metadata");
+  expect(getThreadMode("child", HOME)).toBe("metadata");
+});
+
+it("prunes stale roots while retaining recent turn snapshots", () => {
+  const old = Date.now() - 8 * 24 * 60 * 60 * 1000;
+  vol.fromJSON({
+    [FILE]: JSON.stringify({
+      version: 2,
+      threads: { stale: { updatedAt: old } },
+      turns: { old: { mode: "full", root: "stale", updatedAt: old } },
+      roots: { child: { root: "stale", updatedAt: old } },
+      pending: { stale: [{ createdAt: old }] },
+    }),
+  });
+  setThreadMode("live", "metadata", HOME);
+  const state = readTracingState(HOME).state;
+  expect(state.threads.stale).toBeUndefined();
+  expect(state.turns.old).toBeUndefined();
+  expect(state.roots.child).toBeUndefined();
+  expect(state.pending.stale).toBeUndefined();
+});


### PR DESCRIPTION
### Summary
- add exact sticky `/trace on`, `/trace off`, and `/trace status` controls using Codex prompt and stop hooks
- persist immutable per-turn modes so transcript reparsing cannot backfill muted content
- retain trace topology and strict safe metadata while sanitizing parent baggage and replica updates in metadata-only mode
- fail closed on missing snapshots or corrupt configuration/state, preserve subagent inheritance, and garbage-collect stale roots safely
- add payload, config, state, and command regressions, rebuild the plugin distribution, and bump the tracing plugin to 0.0.8

### Verification
- 52 focused tracing tests passed
- formatting passed
- TypeScript passed
- production distribution build passed
- adversarial privacy review passed

Made by [Open SWE](https://openswe.vercel.app/agents/ead9ba92-aefb-5aca-88eb-712865f67ae9)